### PR TITLE
Rename helm→charts references; update gotenberg to 8.36.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
-Thank you for contributing to adnoctem/helm.
+Thank you for contributing to adnoctem/charts.
 Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:
 
-* https://github.com/adnoctem/helm/blob/main/docs/CONTRIBUTING.md
+* https://github.com/adnoctem/charts/blob/main/docs/CONTRIBUTING.md
 * https://helm.sh/docs/chart_best_practices/
 
 For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,5 +79,5 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm"
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
           done

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helm Charts <img src="https://raw.githubusercontent.com/cncf/artwork/892ce913bbce895ddbd99f981917fcf93050a8ca/projects/helm/icon/color/helm-icon-color.svg" alt="Helm Logo" align="right" width="225"/>
 
-[![License](https://img.shields.io/github/license/adnoctem/helm?label=License)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/github/license/adnoctem/charts?label=License)](https://opensource.org/licenses/MIT)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/adnoctem)](https://artifacthub.io/packages/search?repo=adnoctem&sort=relevance)
-[![CI Status](https://github.com/adnoctem/helm/actions/workflows/release.yaml/badge.svg)](https://github.com/adnoctem/helm/blob/main/.github/workflows/ci-pipeline.yml)
+[![CI Status](https://github.com/adnoctem/charts/actions/workflows/release.yaml/badge.svg)](https://github.com/adnoctem/charts/blob/main/.github/workflows/ci-pipeline.yml)
 [![Renovate](https://img.shields.io/badge/Renovate-enabled-brightgreen?logo=renovatebot&logoColor=1DDEDD)](https://renovatebot.com/)
 
 A collection of open-source [MIT][license]-licensed [_Helm Charts_][helm] written and maintained by `Ad Noctem Collective` for
@@ -19,14 +19,14 @@ information.
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install <RELEASE_NAME> adnoctem/<CHART_NAME>
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/<CHART_NAME>:<VERSION>
+helm install oci://ghcr.io/adnoctem/charts/<CHART_NAME>:<VERSION>
 ```
 
 ## 📖 Overview

--- a/charts/activepieces/Chart.yaml
+++ b/charts/activepieces/Chart.yaml
@@ -25,7 +25,7 @@ keywords:
   - zapier
   - n8n
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -43,9 +43,9 @@ annotations:
       image: docker.io/activepieces/activepieces:0.28.0
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Activepieces Homepage
       url: https://www.activepieces.com/
     - name: Activepieces Documentation

--- a/charts/activepieces/Chart.yaml
+++ b/charts/activepieces/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 0.28.0
 kubeVersion: ">=1.26.0-0"
 name: activepieces
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/activepieces/README.md
+++ b/charts/activepieces/README.md
@@ -32,14 +32,14 @@ on [Docker Hub](https://hub.docker.com/r/activepieces/activepieces).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install activepieces adnoctem/activepieces --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/activepieces:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/activepieces:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/activepieces/ci/test-values.yaml
+++ b/charts/activepieces/ci/test-values.yaml
@@ -1,7 +1,7 @@
 kind: StatefulSet
 
 activepieces:
-  domain: activepieces.helm.internal
+  domain: activepieces.charts.internal
   configPath: ""
   database: postgres
 
@@ -76,7 +76,7 @@ ingress:
   tls:
     - secretName: activepieces-ingress-tls
       hosts:
-        - activepieces.helm.internal
+        - activepieces.charts.internal
 
 postgresql:
   enabled: true

--- a/charts/activepieces/values.yaml
+++ b/charts/activepieces/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/activepieces.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/cachet/Chart.yaml
+++ b/charts/cachet/Chart.yaml
@@ -26,7 +26,7 @@ keywords:
   - uptime-kuma
   - cachet
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -44,9 +44,9 @@ annotations:
       image: docker.io/cachethq/docker:2.3.15
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Cachet Homepage
       url: https://cachethq.io/
     - name: Cachet Documentation

--- a/charts/cachet/Chart.yaml
+++ b/charts/cachet/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.3.15
 kubeVersion: ">=1.26.0-0"
 name: cachet
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/cachet/README.md
+++ b/charts/cachet/README.md
@@ -27,14 +27,14 @@ on [Docker Hub](https://hub.docker.com/r/cachethq/docker/).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install cachet adnoctem/cachet --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/cachet:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/cachet:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/cachet/ci/test-values.yaml
+++ b/charts/cachet/ci/test-values.yaml
@@ -19,7 +19,6 @@ cachet:
 
   database:
     driver: pgsql
-    host: cachet-postgresql
     port: "5432"
     name: cachet
     user: cachet
@@ -28,7 +27,7 @@ cachet:
 
   redis:
     host: ""
-    port: "5432"
+    port: "6379"
     database: ""
 
 ingress:

--- a/charts/cachet/ci/test-values.yaml
+++ b/charts/cachet/ci/test-values.yaml
@@ -1,5 +1,5 @@
 cachet:
-  url: "cachet.helm.internal"
+  url: "cachet.charts.internal"
   env: production
   debug: false
   emoji: false
@@ -39,7 +39,7 @@ ingress:
   tls:
     - secretName: cachet-ingress-tls
       hosts:
-        - "cachet.helm.internal"
+        - "cachet.charts.internal"
 
 livenessProbe:
   enabled: true

--- a/charts/cachet/templates/_helpers.tpl
+++ b/charts/cachet/templates/_helpers.tpl
@@ -102,6 +102,30 @@ Define the Secret names
 {{- end -}}
 
 {{/*
+Resolve the PostgreSQL host: explicit value wins, otherwise fall back to the
+bundled subchart's generated service name (only when it's actually enabled).
+*/}}
+{{- define "cachet.database.host" -}}
+{{- if .Values.cachet.database.host -}}
+{{- printf "%s" .Values.cachet.database.host }}
+{{- else if .Values.postgresql.enabled -}}
+{{- printf "%s-%s" .Release.Name "postgresql" }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the Redis host: explicit value wins, otherwise fall back to the
+bundled subchart's generated service name (only when it's actually enabled).
+*/}}
+{{- define "cachet.redis.host" -}}
+{{- if .Values.cachet.redis.host -}}
+{{- printf "%s" .Values.cachet.redis.host }}
+{{- else if .Values.redis.enabled -}}
+{{- printf "%s-%s" .Release.Name "redis-master" }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Obtain the API version for the Pod Disruption Budget
 */}}
 {{- define "cachet.pdb.apiVersion" -}}

--- a/charts/cachet/templates/configmap.yaml
+++ b/charts/cachet/templates/configmap.yaml
@@ -23,8 +23,9 @@ data:
     Database settings
   */}}
   DB_DRIVER: {{ .Values.cachet.database.driver | quote }}
-  {{- if .Values.cachet.database.host }}
-  DB_HOST: {{ .Values.cachet.database.host | quote }}
+  {{- $dbHost := include "cachet.database.host" . }}
+  {{- if $dbHost }}
+  DB_HOST: {{ $dbHost | quote }}
   {{- end }}
   {{- if .Values.cachet.database.port }}
   DB_PORT: {{ .Values.cachet.database.port | quote }}
@@ -74,8 +75,9 @@ data:
   {{- /*
     Redis settings
   */}}
-  {{- if .Values.cachet.redis.host }}
-  REDIS_HOST: {{ .Values.cachet.redis.host | quote }}
+  {{- $redisHost := include "cachet.redis.host" . }}
+  {{- if $redisHost }}
+  REDIS_HOST: {{ $redisHost | quote }}
   {{- end }}
   {{- if .Values.cachet.redis.database }}
   REDIS_DATABASE: {{ .Values.cachet.redis.database | quote }}

--- a/charts/cachet/values.yaml
+++ b/charts/cachet/values.yaml
@@ -128,7 +128,7 @@ cachet:
     host: ""
     ## @param cachet.database.port [string] The database port, ignored in case of `sqlite`
     ##
-    port: 5432
+    port: "5432"
     ## @param cachet.database.name [string] The database name
     ##
     name: cachet
@@ -180,7 +180,7 @@ cachet:
     host: ""
     ## @param cachet.redis.port [string] The Redis port, ignored in case of `sqlite`
     ##
-    port: 5432
+    port: "6379"
     ## @param cachet.redis.database [string] The Redis database name
     ##
     database: ""

--- a/charts/cachet/values.yaml
+++ b/charts/cachet/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/cachet.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/gobackup/Chart.yaml
+++ b/charts/gobackup/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - cloud-storage
   - s3
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -35,9 +35,9 @@ annotations:
       image: docker.io/huacnlee/gobackup:v2.11.2
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: GoBackup Documentation
       url: https://gobackup.github.io/
     - name: GoBackup GitHub Repository

--- a/charts/gobackup/Chart.yaml
+++ b/charts/gobackup/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.11.2
 kubeVersion: ">=1.26.0-0"
 name: gobackup
-version: 0.3.1
+version: 0.3.2
 description: GoBackup is a CLI and Web UI for database backups to local, cloud or remote storage with notification support
 home: https://gobackup.github.io/
 icon: https://user-images.githubusercontent.com/5518/205909959-12b92929-4ac5-4bb5-9111-6f9a3ed76cf6.png

--- a/charts/gobackup/README.md
+++ b/charts/gobackup/README.md
@@ -15,14 +15,14 @@ on [Docker Hub](https://hub.docker.com/r/huacnlee/gobackup).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install gobackup adnoctem/gobackup --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/gobackup:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/gobackup:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/gobackup/ci/test-values.yaml
+++ b/charts/gobackup/ci/test-values.yaml
@@ -53,9 +53,9 @@ ingress:
   tls:
     - secretName: gobackup-ingress-tls
       hosts:
-        - gobackup.helm.internal
+        - gobackup.charts.internal
   hosts:
-    - host: gobackup.helm.internal
+    - host: gobackup.charts.internal
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/gobackup/values.yaml
+++ b/charts/gobackup/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/gobackup.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - html
   - markdown
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -35,9 +35,9 @@ annotations:
       image: docker.io/gotenberg/gotenberg:8.7.0
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Gotenberg Homepage
       url: https://gotenberg.dev/
     - name: Gotenberg Documentation

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 apiVersion: v2
-appVersion: 8.7.0
+appVersion: 8.36.0
 kubeVersion: ">=1.26.0-0"
 name: gotenberg
-version: 0.3.1
+version: 0.4.0
 description: Gotenberg is a Docker-powered stateless API for PDF files.
 home: https://gotenberg.dev/
 icon: https://user-images.githubusercontent.com/8983173/130322857-185831e2-f041-46eb-a17f-0a69d066c4e5.png
@@ -32,7 +32,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
     - name: gotenberg
-      image: docker.io/gotenberg/gotenberg:8.7.0
+      image: docker.io/gotenberg/gotenberg:8.36.0
   artifacthub.io/links: |
     - name: Source
       url: https://github.com/adnoctem/charts
@@ -50,3 +50,13 @@ annotations:
       description: repository owner changed from fmjstudios to adnoctem
     - kind: fixed
       description: verify rotation of expired GPG key
+    - kind: changed
+      description: bump appVersion to 8.36.0 (from 8.7.0) - see README Upgrading section for breaking changes
+    - kind: added
+      description: expose OpenTelemetry, LibreOffice outbound-filtering, Chromium/webhook IP-class filtering, environment-proxy opt-in, and route-telemetry controls introduced in Gotenberg 8.11-8.36
+    - kind: removed
+      description: chromium.incognito removed (silently ignored upstream since 8.25)
+    - kind: changed
+      description: gotenberg.pdf.engines replaced by convertEngines/readMetadataEngines/writeMetadataEngines (upstream 8.13)
+    - kind: fixed
+      description: readinessProbe and startupProbe templates no longer incorrectly render as livenessProbe

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -14,14 +14,14 @@ on [Docker Hub](https://hub.docker.com/r/gotenberg/gotenberg).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install gotenberg adnoctem/gotenberg --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/gotenberg:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/gotenberg:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -39,6 +39,37 @@ The chart supports the configuration of all [Gotenberg CLI options](https://gote
 the `gotenberg` key in Helm's _values_ and makes use of the official Docker Hub container image, although this is
 configurable via the Image Parameters.
 
+## Upgrading
+
+### To 0.4.0 (Gotenberg 8.7.0 -> 8.36.0)
+
+This is a breaking chart release. Review the following before upgrading:
+
+- `gotenberg.chromium.incognito` has been removed. Upstream Gotenberg silently ignores this flag since 8.25 -
+  remove it from your values if set.
+- `gotenberg.pdf.engines` has been replaced by three separate keys: `gotenberg.pdf.convertEngines`,
+  `gotenberg.pdf.readMetadataEngines`, and `gotenberg.pdf.writeMetadataEngines` (upstream 8.13).
+- `gotenberg.api.traceHeader` has been renamed to `gotenberg.api.correlationIdHeader` (upstream 8.29).
+- `gotenberg.prometheus.disableRouteLogging` has been renamed to `gotenberg.prometheus.disableRouteTelemetry`
+  (upstream 8.29).
+- `gotenberg.logging.format` now emits `--log-std-format` instead of the deprecated `--log-format` (upstream 8.29).
+- **Outbound proxy behavior changed (upstream 8.35, breaking):** Gotenberg no longer implicitly inherits
+  `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` for outbound requests. If you rely on an environment proxy for Chromium,
+  LibreOffice, webhook delivery, or `downloadFrom`, set the corresponding new `enableEnvironmentProxy` value to
+  `true` (`gotenberg.chromium.enableEnvironmentProxy`, `gotenberg.libreOffice.enableEnvironmentProxy`,
+  `gotenberg.webhook.enableEnvironmentProxy`).
+- **SSRF-hardening flags are available but default permissive** (upstream 8.31 briefly defaulted to strict, then
+  reverted in 8.32 after breaking internal-network deployments). If your Gotenberg instance is internet-facing,
+  consider opting into `gotenberg.chromium.denyPrivateIps`, `gotenberg.webhook.denyPrivateIps`, and
+  `gotenberg.libreOffice.denyPrivateIps`.
+- New optional `gotenberg.openTelemetry` section replaces/complements the existing Prometheus metrics config -
+  see [Gotenberg's configuration docs](https://gotenberg.dev/docs/configuration) for the full set of `OTEL_*`
+  environment variables it forwards.
+- A pre-existing template bug has been fixed: `readinessProbe` and `startupProbe` previously both rendered as a
+  second/third `livenessProbe` block due to a copy-paste error. If you had `readinessProbe.enabled: true` or
+  `startupProbe.enabled: true` set, the correct probe type is now applied - review your probe behavior after
+  upgrading.
+
 ## Parameters
 
 ### Image parameters
@@ -47,7 +78,7 @@ configurable via the Image Parameters.
 | ------------------- | ------------------------------------------------------------------- | --------------------- |
 | `image.registry`    | The Docker registry to pull the image from                          | `docker.io`           |
 | `image.repository`  | The registry repository to pull the image from                      | `gotenberg/gotenberg` |
-| `image.tag`         | The image tag to pull                                               | `8.7.0`               |
+| `image.tag`         | The image tag to pull                                               | `8.36.0`              |
 | `image.digest`      | The image digest to pull                                            | `""`                  |
 | `image.pullPolicy`  | The Kubernetes image pull policy                                    | `IfNotPresent`        |
 | `image.pullSecrets` | A list of secrets to use for pulling images from private registries | `[]`                  |
@@ -61,61 +92,93 @@ configurable via the Image Parameters.
 
 ### Gotenberg Configuration parameters
 
-| Name                                          | Description                                                                      | Value       |
-| --------------------------------------------- | -------------------------------------------------------------------------------- | ----------- |
-| `gotenberg.api.port`                          | The port the API should listen on                                                | `3000`      |
-| `gotenberg.api.tlsCertFile`                   | Disable health check logging                                                     | `""`        |
-| `gotenberg.api.tlsKeyFile`                    | Disable health check logging                                                     | `""`        |
-| `gotenberg.api.startTimeout`                  | Set the time limit for the API to start                                          | `30s`       |
-| `gotenberg.api.timeout`                       | Set the time limit for requests                                                  | `30s`       |
-| `gotenberg.api.rootPath`                      | Set the root path of the API                                                     | `"/"`       |
-| `gotenberg.api.traceHeader`                   | Set the header name to use for identifying requests                              | `""`        |
-| `gotenberg.api.disableHealthCheckLogging`     | Disable health check logging                                                     | `false`     |
-| `gotenberg.basicAuth.enabled`                 | Enable basic authentication                                                      | `false`     |
-| `gotenberg.basicAuth.username`                | Set a username for HTTP Basic Auth                                               | `""`        |
-| `gotenberg.basicAuth.password`                | Set a password for HTTP Basic Auth                                               | `""`        |
-| `gotenberg.basicAuth.existingSecret`          | The name of an existing `basic-auth` secret                                      | `""`        |
-| `gotenberg.chromium.restartAfter`             | Number of conversions after which Chromium will auto-restart                     | `0`         |
-| `gotenberg.chromium.maxQueueSize`             | Maximum request queue size for Chromium                                          | `0`         |
-| `gotenberg.chromium.autoStart`                | Automatically launch Chromium upon initialization if set to true                 | `false`     |
-| `gotenberg.chromium.startTimeout`             | Maximum duration to wait for Chromium to start or restart                        | `20s`       |
-| `gotenberg.chromium.allowFileAccessFromFiles` | Allow file:// URIs to read other file:// URIs                                    | `false`     |
-| `gotenberg.chromium.allowInsecureLocalhost`   | Ignore TLS/SSL errors on localhost                                               | `false`     |
-| `gotenberg.chromium.allowList`                | Set the allowed URLs for Chromium using a regular expression - defaults to 'All' | `""`        |
-| `gotenberg.chromium.denyList`                 | Set the denied URLs for Chromium using a regular expression                      | `""`        |
-| `gotenberg.chromium.ignoreCertificateErrors`  | Ignore the certificate errors                                                    | `false`     |
-| `gotenberg.chromium.disableWebSecurity`       | Don't enforce the same-origin policy                                             | `false`     |
-| `gotenberg.chromium.incognito`                | Start Chromium with incognito mode                                               | `false`     |
-| `gotenberg.chromium.hostResolverRules`        | Set custom mappings to the host resolver                                         | `""`        |
-| `gotenberg.chromium.proxyServer`              | Set the outbound proxy server; this switch only affects HTTP and HTTPS requests  | `""`        |
-| `gotenberg.chromium.clearCache`               | Clear Chromium cache between each conversion                                     | `false`     |
-| `gotenberg.chromium.clearCookies`             | Clear Chromium cookies between each conversion                                   | `false`     |
-| `gotenberg.chromium.disableJavaScript`        | Disable JavaScript                                                               | `false`     |
-| `gotenberg.chromium.disableRoutes`            | Disable the routes                                                               | `false`     |
-| `gotenberg.libreOffice.restartAfter`          | Number of conversions after which LibreOffice will automatically restart         | `10`        |
-| `gotenberg.libreOffice.maxQueueSize`          | Maximum request queue size for LibreOffice                                       | `0`         |
-| `gotenberg.libreOffice.autoStart`             | Automatically launch LibreOffice upon initialization if set to true              | `false`     |
-| `gotenberg.libreOffice.startTimeout`          | Maximum duration to wait for LibreOffice to start or restart                     | `20s`       |
-| `gotenberg.libreOffice.disableRoutes`         | Disable the route                                                                | `false`     |
-| `gotenberg.pdf.engines`                       | Set the PDF engines and their order - defaults to 'All'                          | `""`        |
-| `gotenberg.pdf.disableRoutes`                 | Disable the routes                                                               | `false`     |
-| `gotenberg.webhook.allowList`                 | Set the allowed URLs for the webhook feature using a regular expression          | `""`        |
-| `gotenberg.webhook.denyList`                  | Set the denied URLs for the webhook feature using a regular expression           | `""`        |
-| `gotenberg.webhook.errorAllowList`            | Set the allowed URLs in case of an error using a regular expression              | `""`        |
-| `gotenberg.webhook.errorDenyList`             | Set the denied URLs in case of an error using a regular expression               | `""`        |
-| `gotenberg.webhook.maxRetry`                  | Set the maximum number of retries                                                | `4`         |
-| `gotenberg.webhook.retryMinWait`              | Set the minimum duration to wait before trying to call the webhook again         | `1s`        |
-| `gotenberg.webhook.retryMaxWait`              | Set the maximum duration to wait before trying to call the webhook again         | `30s`       |
-| `gotenberg.webhook.clientTimeout`             | Set the time limit for requests to the webhook                                   | `30s`       |
-| `gotenberg.webhook.disable`                   | Disable the webhook feature                                                      | `false`     |
-| `gotenberg.prometheus.collectInterval`        | Set the interval for collecting modules' metrics                                 | `1s`        |
-| `gotenberg.prometheus.namespace`              | Set the namespace of modules' metrics                                            | `gotenberg` |
-| `gotenberg.prometheus.disableCollect`         | Disable the collect of metrics                                                   | `false`     |
-| `gotenberg.prometheus.disableRouteLogging`    | Disable the route logging                                                        | `false`     |
-| `gotenberg.logging.format`                    | Specify the format of logging                                                    | `auto`      |
-| `gotenberg.logging.level`                     | Choose the level of logging detail                                               | `info`      |
-| `gotenberg.logging.fieldsPrefix`              | Prepend a specified prefix to each field in the logs                             | `""`        |
-| `gotenberg.shutdown.duration`                 | Set the graceful shutdown duration                                               | `30s`       |
+| Name                                           | Description                                                                        | Value                   |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------- |
+| `gotenberg.api.port`                           | The port the API should listen on                                                  | `3000`                  |
+| `gotenberg.api.tlsCertFile`                    | Disable health check logging                                                       | `""`                    |
+| `gotenberg.api.tlsKeyFile`                     | Disable health check logging                                                       | `""`                    |
+| `gotenberg.api.startTimeout`                   | Set the time limit for the API to start                                            | `30s`                   |
+| `gotenberg.api.timeout`                        | Set the time limit for requests                                                    | `30s`                   |
+| `gotenberg.api.rootPath`                       | Set the root path of the API                                                       | `"/"`                   |
+| `gotenberg.api.correlationIdHeader`            | Set the header name to use for identifying requests                                | `""`                    |
+| `gotenberg.api.disableHealthCheckLogging`      | Disable health check route telemetry                                               | `false`                 |
+| `gotenberg.api.disableRootRouteTelemetry`      | Disable telemetry for the root ("/") route                                         | `false`                 |
+| `gotenberg.api.disableDebugRouteTelemetry`     | Disable telemetry for the /debug route                                             | `false`                 |
+| `gotenberg.api.disableVersionRouteTelemetry`   | Disable telemetry for the /version route                                           | `false`                 |
+| `gotenberg.api.bodyLimit`                      | Set a cap on multipart/form-data request size, e.g. "5MB"                          | `""`                    |
+| `gotenberg.api.bindIp`                         | Bind the API to a specific IP address                                              | `0.0.0.0`               |
+| `gotenberg.api.enableDebugRoute`               | Expose the /debug route with full instance configuration                           | `false`                 |
+| `gotenberg.api.enableOidcAuth`                 | Enable OIDC bearer token authentication (mutually exclusive with basicAuth)        | `false`                 |
+| `gotenberg.basicAuth.enabled`                  | Enable basic authentication                                                        | `false`                 |
+| `gotenberg.basicAuth.username`                 | Set a username for HTTP Basic Auth                                                 | `""`                    |
+| `gotenberg.basicAuth.password`                 | Set a password for HTTP Basic Auth                                                 | `""`                    |
+| `gotenberg.basicAuth.existingSecret`           | The name of an existing `basic-auth` secret                                        | `""`                    |
+| `gotenberg.chromium.restartAfter`              | Number of conversions after which Chromium will auto-restart                       | `0`                     |
+| `gotenberg.chromium.maxQueueSize`              | Maximum request queue size for Chromium                                            | `0`                     |
+| `gotenberg.chromium.autoStart`                 | Automatically launch Chromium upon initialization if set to true                   | `false`                 |
+| `gotenberg.chromium.startTimeout`              | Maximum duration to wait for Chromium to start or restart                          | `20s`                   |
+| `gotenberg.chromium.allowFileAccessFromFiles`  | Allow file:// URIs to read other file:// URIs                                      | `false`                 |
+| `gotenberg.chromium.allowInsecureLocalhost`    | Ignore TLS/SSL errors on localhost                                                 | `false`                 |
+| `gotenberg.chromium.allowList`                 | Set the allowed URLs for Chromium using a regular expression - defaults to 'All'   | `""`                    |
+| `gotenberg.chromium.denyList`                  | Set the denied URLs for Chromium using a regular expression                        | `""`                    |
+| `gotenberg.chromium.ignoreCertificateErrors`   | Ignore the certificate errors                                                      | `false`                 |
+| `gotenberg.chromium.disableWebSecurity`        | Don't enforce the same-origin policy                                               | `false`                 |
+| `gotenberg.chromium.hostResolverRules`         | Set custom mappings to the host resolver                                           | `""`                    |
+| `gotenberg.chromium.proxyServer`               | Set the outbound proxy server; this switch only affects HTTP and HTTPS requests    | `""`                    |
+| `gotenberg.chromium.clearCache`                | Clear Chromium cache between each conversion                                       | `false`                 |
+| `gotenberg.chromium.clearCookies`              | Clear Chromium cookies between each conversion                                     | `false`                 |
+| `gotenberg.chromium.disableJavaScript`         | Disable JavaScript                                                                 | `false`                 |
+| `gotenberg.chromium.disableRoutes`             | Disable the routes                                                                 | `false`                 |
+| `gotenberg.chromium.maxConcurrency`            | Maximum number of simultaneous Chromium conversions                                | `6`                     |
+| `gotenberg.chromium.idleShutdownTimeout`       | Auto-stop Chromium after this idle period; set to "0s" to disable                  | `"0s"`                  |
+| `gotenberg.chromium.clearStorage`              | Clear browser storage between each conversion                                      | `false`                 |
+| `gotenberg.chromium.denyPrivateIps`            | Reject Chromium navigations/sub-resources resolving to a non-public IP             | `false`                 |
+| `gotenberg.chromium.denyPublicIps`             | Reject Chromium navigations/sub-resources resolving to a public IP                 | `false`                 |
+| `gotenberg.chromium.enableEnvironmentProxy`    | Route outbound Chromium traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY            | `false`                 |
+| `gotenberg.libreOffice.restartAfter`           | Number of conversions after which LibreOffice will automatically restart           | `10`                    |
+| `gotenberg.libreOffice.maxQueueSize`           | Maximum request queue size for LibreOffice                                         | `0`                     |
+| `gotenberg.libreOffice.autoStart`              | Automatically launch LibreOffice upon initialization if set to true                | `false`                 |
+| `gotenberg.libreOffice.startTimeout`           | Maximum duration to wait for LibreOffice to start or restart                       | `20s`                   |
+| `gotenberg.libreOffice.disableRoutes`          | Disable the route                                                                  | `false`                 |
+| `gotenberg.libreOffice.idleShutdownTimeout`    | Auto-stop LibreOffice after this idle period; set to "0s" to disable               | `"0s"`                  |
+| `gotenberg.libreOffice.allowList`              | Set the allowed URLs for LibreOffice's outbound fetches using a regular expression | `""`                    |
+| `gotenberg.libreOffice.denyList`               | Set the denied URLs for LibreOffice's outbound fetches using a regular expression  | `""`                    |
+| `gotenberg.libreOffice.denyPrivateIps`         | Reject LibreOffice outbound fetches resolving to a non-public IP                   | `false`                 |
+| `gotenberg.libreOffice.denyPublicIps`          | Reject LibreOffice outbound fetches resolving to a public IP                       | `false`                 |
+| `gotenberg.libreOffice.enableEnvironmentProxy` | Route outbound LibreOffice traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY         | `false`                 |
+| `gotenberg.pdf.convertEngines`                 | Set the PDF conversion engines and their order                                     | `libreoffice-pdfengine` |
+| `gotenberg.pdf.readMetadataEngines`            | Set the PDF metadata-reading engines and their order                               | `exiftool`              |
+| `gotenberg.pdf.writeMetadataEngines`           | Set the PDF metadata-writing engines and their order                               | `exiftool`              |
+| `gotenberg.pdf.disableRoutes`                  | Disable the routes                                                                 | `false`                 |
+| `gotenberg.webhook.allowList`                  | Set the allowed URLs for the webhook feature using a regular expression            | `""`                    |
+| `gotenberg.webhook.denyList`                   | Set the denied URLs for the webhook feature using a regular expression             | `""`                    |
+| `gotenberg.webhook.errorAllowList`             | Set the allowed URLs in case of an error using a regular expression                | `""`                    |
+| `gotenberg.webhook.errorDenyList`              | Set the denied URLs in case of an error using a regular expression                 | `""`                    |
+| `gotenberg.webhook.maxRetry`                   | Set the maximum number of retries                                                  | `4`                     |
+| `gotenberg.webhook.retryMinWait`               | Set the minimum duration to wait before trying to call the webhook again           | `1s`                    |
+| `gotenberg.webhook.retryMaxWait`               | Set the maximum duration to wait before trying to call the webhook again           | `30s`                   |
+| `gotenberg.webhook.clientTimeout`              | Set the time limit for requests to the webhook                                     | `30s`                   |
+| `gotenberg.webhook.disable`                    | Disable the webhook feature                                                        | `false`                 |
+| `gotenberg.webhook.denyPrivateIps`             | Reject webhook URLs (success, error, events) resolving to a non-public IP          | `false`                 |
+| `gotenberg.webhook.denyPublicIps`              | Reject webhook URLs resolving to a public IP                                       | `false`                 |
+| `gotenberg.webhook.enableEnvironmentProxy`     | Route outbound webhook traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY             | `false`                 |
+| `gotenberg.prometheus.collectInterval`         | Set the interval for collecting modules' metrics                                   | `1s`                    |
+| `gotenberg.prometheus.namespace`               | Set the namespace of modules' metrics                                              | `gotenberg`             |
+| `gotenberg.prometheus.disableCollect`          | Disable the collect of metrics                                                     | `false`                 |
+| `gotenberg.prometheus.disableRouteTelemetry`   | Disable telemetry for the /prometheus route                                        | `false`                 |
+| `gotenberg.prometheus.metricsPath`             | Customise the Prometheus scrape endpoint path                                      | `""`                    |
+| `gotenberg.openTelemetry.enabled`              | Enable OpenTelemetry tracing/metrics/logging env vars below                        | `false`                 |
+| `gotenberg.openTelemetry.tracesExporter`       | Sets OTEL_TRACES_EXPORTER                                                          | `""`                    |
+| `gotenberg.openTelemetry.metricsExporter`      | Sets OTEL_METRICS_EXPORTER                                                         | `""`                    |
+| `gotenberg.openTelemetry.logsExporter`         | Sets OTEL_LOGS_EXPORTER                                                            | `""`                    |
+| `gotenberg.openTelemetry.exporterOtlpEndpoint` | Sets OTEL_EXPORTER_OTLP_ENDPOINT                                                   | `""`                    |
+| `gotenberg.openTelemetry.extraEnv`             | Extra OTEL_* environment variables not covered above                               | `{}`                    |
+| `gotenberg.logging.format`                     | Specify the format of logging                                                      | `auto`                  |
+| `gotenberg.logging.level`                      | Choose the level of logging detail                                                 | `info`                  |
+| `gotenberg.logging.levelCase`                  | Set the level field casing in standard output                                      | `lower`                 |
+| `gotenberg.logging.fieldsPrefix`               | Prepend a specified prefix to each field in the logs                               | `""`                    |
+| `gotenberg.logging.enableGcpFields`            | Use GCP Cloud Run-compatible structured log field names                            | `false`                 |
+| `gotenberg.shutdown.duration`                  | Set the graceful shutdown duration                                                 | `30s`                   |
 
 ### Common Secret parameters
 
@@ -215,20 +278,21 @@ configurable via the Image Parameters.
 
 ### Pod settings
 
-| Name                | Description                                               | Value |
-| ------------------- | --------------------------------------------------------- | ----- |
-| `replicas`          | The amount of replicas Gotenberg deployment should create | `1`   |
-| `resources`         | The resource limits/requests for the Gotenberg pod        | `{}`  |
-| `volumes`           | Define volumes for the Gotenberg pod                      | `[]`  |
-| `volumeMounts`      | Define volumeMounts for the Gotenberg pod                 | `[]`  |
-| `initContainers`    | Define initContainers for the main Gotenberg server       | `[]`  |
-| `nodeSelector`      | Node labels for pod assignment                            | `{}`  |
-| `tolerations`       | Tolerations for pod assignment                            | `[]`  |
-| `affinity`          | Affinity for pod assignment                               | `{}`  |
-| `strategy`          | Specify a deployment strategy for the Gotenberg pod       | `{}`  |
-| `podAnnotations`    | Extra annotations for the Gotenberg pod                   | `{}`  |
-| `podLabels`         | Extra labels for the Gotenberg pod                        | `{}`  |
-| `priorityClassName` | The name of an existing PriorityClass                     | `""`  |
+| Name                | Description                                                    | Value |
+| ------------------- | -------------------------------------------------------------- | ----- |
+| `replicas`          | The amount of replicas Gotenberg deployment should create      | `1`   |
+| `resources`         | The resource limits/requests for the Gotenberg pod             | `{}`  |
+| `extraEnvVars`      | Extra environment variables for the Gotenberg pod, e.g. for TZ | `[]`  |
+| `volumes`           | Define volumes for the Gotenberg pod                           | `[]`  |
+| `volumeMounts`      | Define volumeMounts for the Gotenberg pod                      | `[]`  |
+| `initContainers`    | Define initContainers for the main Gotenberg server            | `[]`  |
+| `nodeSelector`      | Node labels for pod assignment                                 | `{}`  |
+| `tolerations`       | Tolerations for pod assignment                                 | `[]`  |
+| `affinity`          | Affinity for pod assignment                                    | `{}`  |
+| `strategy`          | Specify a deployment strategy for the Gotenberg pod            | `{}`  |
+| `podAnnotations`    | Extra annotations for the Gotenberg pod                        | `{}`  |
+| `podLabels`         | Extra labels for the Gotenberg pod                             | `{}`  |
+| `priorityClassName` | The name of an existing PriorityClass                          | `""`  |
 
 ### Security context settings
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -172,7 +172,7 @@ This is a breaking chart release. Review the following before upgrading:
 | `gotenberg.openTelemetry.metricsExporter`      | Sets OTEL_METRICS_EXPORTER                                                         | `""`                    |
 | `gotenberg.openTelemetry.logsExporter`         | Sets OTEL_LOGS_EXPORTER                                                            | `""`                    |
 | `gotenberg.openTelemetry.exporterOtlpEndpoint` | Sets OTEL_EXPORTER_OTLP_ENDPOINT                                                   | `""`                    |
-| `gotenberg.openTelemetry.extraEnv`             | Extra OTEL_* environment variables not covered above                               | `{}`                    |
+| `gotenberg.openTelemetry.extraEnv`             | Extra OTEL\_\* environment variables not covered above                             | `{}`                    |
 | `gotenberg.logging.format`                     | Specify the format of logging                                                      | `auto`                  |
 | `gotenberg.logging.level`                      | Choose the level of logging detail                                                 | `info`                  |
 | `gotenberg.logging.levelCase`                  | Set the level field casing in standard output                                      | `lower`                 |

--- a/charts/gotenberg/ci/test-values.yaml
+++ b/charts/gotenberg/ci/test-values.yaml
@@ -4,14 +4,14 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: mkcert-development-issuer
   hosts:
-    - host: gotenberg.helm.internal
+    - host: gotenberg.charts.internal
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls:
     - secretName: gotenberg-ingress-tls
       hosts:
-        - gotenberg.helm.internal
+        - gotenberg.charts.internal
 
 livenessProbe:
   enabled: true

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -55,11 +55,32 @@ spec:
           {{- if ne .Values.gotenberg.api.rootPath "/" }}
             - --api-root-path={{ .Values.gotenberg.api.rootPath }}
           {{- end }}
-          {{- if .Values.gotenberg.api.traceHeader }}
-            - --api-trace-header={{ .Values.gotenberg.api.traceHeader }}
+          {{- if .Values.gotenberg.api.correlationIdHeader }}
+            - --api-correlation-id-header={{ .Values.gotenberg.api.correlationIdHeader }}
           {{- end }}
           {{- if .Values.gotenberg.api.disableHealthCheckLogging }}
-            - --api-disable-health-check-logging={{ .Values.gotenberg.api.disableHealthCheckLogging }}
+            - --api-disable-health-check-route-telemetry={{ .Values.gotenberg.api.disableHealthCheckLogging }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.disableRootRouteTelemetry }}
+            - --api-disable-root-route-telemetry={{ .Values.gotenberg.api.disableRootRouteTelemetry }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.disableDebugRouteTelemetry }}
+            - --api-disable-debug-route-telemetry={{ .Values.gotenberg.api.disableDebugRouteTelemetry }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.disableVersionRouteTelemetry }}
+            - --api-disable-version-route-telemetry={{ .Values.gotenberg.api.disableVersionRouteTelemetry }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.bodyLimit }}
+            - --api-body-limit={{ .Values.gotenberg.api.bodyLimit }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.bindIp }}
+            - --api-bind-ip={{ .Values.gotenberg.api.bindIp }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.enableDebugRoute }}
+            - --api-enable-debug-route={{ .Values.gotenberg.api.enableDebugRoute }}
+          {{- end }}
+          {{- if .Values.gotenberg.api.enableOidcAuth }}
+            - --api-enable-oidc-auth={{ .Values.gotenberg.api.enableOidcAuth }}
           {{- end }}
           {{- /*
             HTTP BasicAuth settings
@@ -100,9 +121,6 @@ spec:
           {{- if .Values.gotenberg.chromium.disableWebSecurity }}
             - --chromium-disable-web-security={{ .Values.gotenberg.chromium.disableWebSecurity }}
           {{- end }}
-          {{- if .Values.gotenberg.chromium.incognito }}
-            - --chromium-incognito={{ .Values.gotenberg.chromium.incognito }}
-          {{- end }}
           {{- if .Values.gotenberg.chromium.hostResolverRules }}
             - --chromium-host-resolver-rules={{ .Values.gotenberg.chromium.hostResolverRules }}
           {{- end }}
@@ -120,6 +138,24 @@ spec:
           {{- end }}
           {{- if .Values.gotenberg.chromium.disableRoutes }}
             - --chromium-disable-routes={{ .Values.gotenberg.chromium.disableRoutes }}
+          {{- end }}
+          {{- if ne (.Values.gotenberg.chromium.maxConcurrency | toString) "6" }}
+            - --chromium-max-concurrency={{ .Values.gotenberg.chromium.maxConcurrency }}
+          {{- end }}
+          {{- if ne .Values.gotenberg.chromium.idleShutdownTimeout "0s" }}
+            - --chromium-idle-shutdown-timeout={{ .Values.gotenberg.chromium.idleShutdownTimeout }}
+          {{- end }}
+          {{- if .Values.gotenberg.chromium.clearStorage }}
+            - --chromium-clear-storage={{ .Values.gotenberg.chromium.clearStorage }}
+          {{- end }}
+          {{- if .Values.gotenberg.chromium.denyPrivateIps }}
+            - --chromium-deny-private-ips={{ .Values.gotenberg.chromium.denyPrivateIps }}
+          {{- end }}
+          {{- if .Values.gotenberg.chromium.denyPublicIps }}
+            - --chromium-deny-public-ips={{ .Values.gotenberg.chromium.denyPublicIps }}
+          {{- end }}
+          {{- if .Values.gotenberg.chromium.enableEnvironmentProxy }}
+            - --chromium-enable-environment-proxy={{ .Values.gotenberg.chromium.enableEnvironmentProxy }}
           {{- end }}
           {{- /*
             LibreOffice settings
@@ -139,11 +175,35 @@ spec:
           {{- if .Values.gotenberg.libreOffice.disableRoutes }}
             - --libreoffice-disable-routes={{ .Values.gotenberg.libreOffice.disableRoutes }}
           {{- end }}
+          {{- if ne .Values.gotenberg.libreOffice.idleShutdownTimeout "0s" }}
+            - --libreoffice-idle-shutdown-timeout={{ .Values.gotenberg.libreOffice.idleShutdownTimeout }}
+          {{- end }}
+          {{- if .Values.gotenberg.libreOffice.allowList }}
+            - --libreoffice-allow-list={{ .Values.gotenberg.libreOffice.allowList }}
+          {{- end }}
+          {{- if .Values.gotenberg.libreOffice.denyList }}
+            - --libreoffice-deny-list={{ .Values.gotenberg.libreOffice.denyList }}
+          {{- end }}
+          {{- if .Values.gotenberg.libreOffice.denyPrivateIps }}
+            - --libreoffice-deny-private-ips={{ .Values.gotenberg.libreOffice.denyPrivateIps }}
+          {{- end }}
+          {{- if .Values.gotenberg.libreOffice.denyPublicIps }}
+            - --libreoffice-deny-public-ips={{ .Values.gotenberg.libreOffice.denyPublicIps }}
+          {{- end }}
+          {{- if .Values.gotenberg.libreOffice.enableEnvironmentProxy }}
+            - --libreoffice-enable-environment-proxy={{ .Values.gotenberg.libreOffice.enableEnvironmentProxy }}
+          {{- end }}
           {{- /*
             PDF settings
           */}}
-          {{- if .Values.gotenberg.pdf.engines }}
-            - --pdfengines-engines={{ .Values.gotenberg.pdf.engines }}
+          {{- if .Values.gotenberg.pdf.convertEngines }}
+            - --pdfengines-convert-engines={{ .Values.gotenberg.pdf.convertEngines }}
+          {{- end }}
+          {{- if .Values.gotenberg.pdf.readMetadataEngines }}
+            - --pdfengines-read-metadata-engines={{ .Values.gotenberg.pdf.readMetadataEngines }}
+          {{- end }}
+          {{- if .Values.gotenberg.pdf.writeMetadataEngines }}
+            - --pdfengines-write-metadata-engines={{ .Values.gotenberg.pdf.writeMetadataEngines }}
           {{- end }}
           {{- if .Values.gotenberg.pdf.disableRoutes }}
             - --pdfengines-disable-routes={{ .Values.gotenberg.pdf.disableRoutes }}
@@ -178,6 +238,15 @@ spec:
           {{- if .Values.gotenberg.webhook.disable }}
             - --webhook-disable={{ .Values.gotenberg.webhook.disable }}
           {{- end }}
+          {{- if .Values.gotenberg.webhook.denyPrivateIps }}
+            - --webhook-deny-private-ips={{ .Values.gotenberg.webhook.denyPrivateIps }}
+          {{- end }}
+          {{- if .Values.gotenberg.webhook.denyPublicIps }}
+            - --webhook-deny-public-ips={{ .Values.gotenberg.webhook.denyPublicIps }}
+          {{- end }}
+          {{- if .Values.gotenberg.webhook.enableEnvironmentProxy }}
+            - --webhook-enable-environment-proxy={{ .Values.gotenberg.webhook.enableEnvironmentProxy }}
+          {{- end }}
           {{- /*
             Prometheus settings
           */}}
@@ -190,20 +259,29 @@ spec:
           {{- if .Values.gotenberg.prometheus.disableCollect }}
             - --prometheus-disable-collect={{ .Values.gotenberg.prometheus.disableCollect }}
           {{- end }}
-          {{- if .Values.gotenberg.prometheus.disableRouteLogging }}
-            - --prometheus-disable-route-logging={{ .Values.gotenberg.prometheus.disableRouteLogging }}
+          {{- if .Values.gotenberg.prometheus.disableRouteTelemetry }}
+            - --prometheus-disable-route-telemetry={{ .Values.gotenberg.prometheus.disableRouteTelemetry }}
+          {{- end }}
+          {{- if .Values.gotenberg.prometheus.metricsPath }}
+            - --prometheus-metrics-path={{ .Values.gotenberg.prometheus.metricsPath }}
           {{- end }}
           {{- /*
             Logging settings
           */}}
           {{- if .Values.gotenberg.logging.format }}
-            - --log-format={{ .Values.gotenberg.logging.format }}
+            - --log-std-format={{ .Values.gotenberg.logging.format }}
           {{- end }}
           {{- if .Values.gotenberg.logging.level }}
             - --log-level={{ .Values.gotenberg.logging.level }}
           {{- end }}
+          {{- if ne .Values.gotenberg.logging.levelCase "lower" }}
+            - --log-std-level-case={{ .Values.gotenberg.logging.levelCase }}
+          {{- end }}
           {{- if .Values.gotenberg.logging.fieldsPrefix }}
             - --log-fields-prefix={{ .Values.gotenberg.logging.fieldsPrefix }}
+          {{- end }}
+          {{- if .Values.gotenberg.logging.enableGcpFields }}
+            - --log-std-enable-gcp-fields={{ .Values.gotenberg.logging.enableGcpFields }}
           {{- end }}
           {{- /*
             Shutdown settings
@@ -223,6 +301,31 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "gotenberg.secret.auth" .) .Values.gotenberg.basicAuth.existingSecret }}
                   key: password
+            {{- end }}
+            {{- if .Values.gotenberg.openTelemetry.enabled }}
+            {{- if .Values.gotenberg.openTelemetry.tracesExporter }}
+            - name: OTEL_TRACES_EXPORTER
+              value: {{ .Values.gotenberg.openTelemetry.tracesExporter | quote }}
+            {{- end }}
+            {{- if .Values.gotenberg.openTelemetry.metricsExporter }}
+            - name: OTEL_METRICS_EXPORTER
+              value: {{ .Values.gotenberg.openTelemetry.metricsExporter | quote }}
+            {{- end }}
+            {{- if .Values.gotenberg.openTelemetry.logsExporter }}
+            - name: OTEL_LOGS_EXPORTER
+              value: {{ .Values.gotenberg.openTelemetry.logsExporter | quote }}
+            {{- end }}
+            {{- if .Values.gotenberg.openTelemetry.exporterOtlpEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.gotenberg.openTelemetry.exporterOtlpEndpoint | quote }}
+            {{- end }}
+            {{- range $key, $value := .Values.gotenberg.openTelemetry.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
           ports:
             - name: http
@@ -252,7 +355,7 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
-          livenessProbe:
+          readinessProbe:
             httpGet:
               path: /
               port: http
@@ -263,7 +366,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.startupProbe.enabled }}
-          livenessProbe:
+          startupProbe:
             httpGet:
               path: /
               port: http

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -1,758 +1,924 @@
 {
-  "title": "Chart Values",
-  "type": "object",
-  "properties": {
-    "image": {
-      "type": "object",
-      "properties": {
-        "registry": {
-          "type": "string",
-          "description": "The Docker registry to pull the image from",
-          "default": "docker.io"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The registry repository to pull the image from",
-          "default": "gotenberg/gotenberg"
-        },
-        "tag": {
-          "type": "string",
-          "description": "The image tag to pull",
-          "default": "8.7.0"
-        },
-        "digest": {
-          "type": "string",
-          "description": "The image digest to pull",
-          "default": ""
-        },
-        "pullPolicy": {
-          "type": "string",
-          "description": "The Kubernetes image pull policy",
-          "default": "IfNotPresent"
-        },
-        "pullSecrets": {
-          "type": "array",
-          "description": "A list of secrets to use for pulling images from private registries",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "nameOverride": {
-      "type": "string",
-      "description": "String to partially override gotenberg.fullname",
-      "default": ""
-    },
-    "fullnameOverride": {
-      "type": "string",
-      "description": "String to fully override gotenberg.fullname",
-      "default": ""
-    },
-    "gotenberg": {
-      "type": "object",
-      "properties": {
-        "api": {
-          "type": "object",
-          "properties": {
-            "port": {
-              "type": "number",
-              "description": "The port the API should listen on",
-              "default": "3000"
-            },
-            "tlsCertFile": {
-              "type": "string",
-              "description": "Disable health check logging",
-              "default": "\"\""
-            },
-            "tlsKeyFile": {
-              "type": "string",
-              "description": "Disable health check logging",
-              "default": "\"\""
-            },
-            "startTimeout": {
-              "type": "string",
-              "description": "Set the time limit for the API to start",
-              "default": "30s"
-            },
-            "timeout": {
-              "type": "string",
-              "description": "Set the time limit for requests",
-              "default": "30s"
-            },
-            "rootPath": {
-              "type": "string",
-              "description": "Set the root path of the API",
-              "default": "\"/\""
-            },
-            "traceHeader": {
-              "type": "string",
-              "description": "Set the header name to use for identifying requests",
-              "default": "\"\""
-            },
-            "disableHealthCheckLogging": {
-              "type": "boolean",
-              "description": "Disable health check logging",
-              "default": "false"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "The Docker registry to pull the image from",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "The registry repository to pull the image from",
+                    "default": "gotenberg/gotenberg"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "The image tag to pull",
+                    "default": "8.36.0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "The image digest to pull",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "The Kubernetes image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "A list of secrets to use for pulling images from private registries",
+                    "default": [],
+                    "items": {}
+                }
             }
-          }
         },
-        "basicAuth": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Enable basic authentication",
-              "default": "false"
-            },
-            "username": {
-              "type": "string",
-              "description": "Set a username for HTTP Basic Auth",
-              "default": "\"\""
-            },
-            "password": {
-              "type": "string",
-              "description": "Set a password for HTTP Basic Auth",
-              "default": "\"\""
-            },
-            "existingSecret": {
-              "type": "string",
-              "description": "The name of an existing `basic-auth` secret",
-              "default": "\"\""
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override gotenberg.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override gotenberg.fullname",
+            "default": ""
+        },
+        "gotenberg": {
+            "type": "object",
+            "properties": {
+                "api": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "number",
+                            "description": "The port the API should listen on",
+                            "default": "3000"
+                        },
+                        "tlsCertFile": {
+                            "type": "string",
+                            "description": "Disable health check logging",
+                            "default": "\"\""
+                        },
+                        "tlsKeyFile": {
+                            "type": "string",
+                            "description": "Disable health check logging",
+                            "default": "\"\""
+                        },
+                        "startTimeout": {
+                            "type": "string",
+                            "description": "Set the time limit for the API to start",
+                            "default": "30s"
+                        },
+                        "timeout": {
+                            "type": "string",
+                            "description": "Set the time limit for requests",
+                            "default": "30s"
+                        },
+                        "rootPath": {
+                            "type": "string",
+                            "description": "Set the root path of the API",
+                            "default": "\"/\""
+                        },
+                        "correlationIdHeader": {
+                            "type": "string",
+                            "description": "Set the header name to use for identifying requests",
+                            "default": "\"\""
+                        },
+                        "disableHealthCheckLogging": {
+                            "type": "boolean",
+                            "description": "Disable health check route telemetry",
+                            "default": "false"
+                        },
+                        "disableRootRouteTelemetry": {
+                            "type": "boolean",
+                            "description": "Disable telemetry for the root (\"/\") route",
+                            "default": "false"
+                        },
+                        "disableDebugRouteTelemetry": {
+                            "type": "boolean",
+                            "description": "Disable telemetry for the /debug route",
+                            "default": "false"
+                        },
+                        "disableVersionRouteTelemetry": {
+                            "type": "boolean",
+                            "description": "Disable telemetry for the /version route",
+                            "default": "false"
+                        },
+                        "bodyLimit": {
+                            "type": "string",
+                            "description": "Set a cap on multipart/form-data request size, e.g. \"5MB\"",
+                            "default": "\"\""
+                        },
+                        "bindIp": {
+                            "type": "string",
+                            "description": "Bind the API to a specific IP address",
+                            "default": "0.0.0.0"
+                        },
+                        "enableDebugRoute": {
+                            "type": "boolean",
+                            "description": "Expose the /debug route with full instance configuration",
+                            "default": "false"
+                        },
+                        "enableOidcAuth": {
+                            "type": "boolean",
+                            "description": "Enable OIDC bearer token authentication (mutually exclusive with basicAuth)",
+                            "default": "false"
+                        }
+                    }
+                },
+                "basicAuth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable basic authentication",
+                            "default": "false"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Set a username for HTTP Basic Auth",
+                            "default": "\"\""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Set a password for HTTP Basic Auth",
+                            "default": "\"\""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "The name of an existing `basic-auth` secret",
+                            "default": "\"\""
+                        }
+                    }
+                },
+                "chromium": {
+                    "type": "object",
+                    "properties": {
+                        "restartAfter": {
+                            "type": "number",
+                            "description": "Number of conversions after which Chromium will auto-restart",
+                            "default": "0"
+                        },
+                        "maxQueueSize": {
+                            "type": "number",
+                            "description": "Maximum request queue size for Chromium",
+                            "default": "0"
+                        },
+                        "autoStart": {
+                            "type": "boolean",
+                            "description": "Automatically launch Chromium upon initialization if set to true",
+                            "default": "false"
+                        },
+                        "startTimeout": {
+                            "type": "string",
+                            "description": "Maximum duration to wait for Chromium to start or restart",
+                            "default": "20s"
+                        },
+                        "allowFileAccessFromFiles": {
+                            "type": "boolean",
+                            "description": "Allow file:// URIs to read other file:// URIs",
+                            "default": "false"
+                        },
+                        "allowInsecureLocalhost": {
+                            "type": "boolean",
+                            "description": "Ignore TLS/SSL errors on localhost",
+                            "default": "false"
+                        },
+                        "allowList": {
+                            "type": "string",
+                            "description": "Set the allowed URLs for Chromium using a regular expression - defaults to 'All'",
+                            "default": "\"\""
+                        },
+                        "denyList": {
+                            "type": "string",
+                            "description": "Set the denied URLs for Chromium using a regular expression",
+                            "default": "\"\""
+                        },
+                        "ignoreCertificateErrors": {
+                            "type": "boolean",
+                            "description": "Ignore the certificate errors",
+                            "default": "false"
+                        },
+                        "disableWebSecurity": {
+                            "type": "boolean",
+                            "description": "Don't enforce the same-origin policy",
+                            "default": "false"
+                        },
+                        "hostResolverRules": {
+                            "type": "string",
+                            "description": "Set custom mappings to the host resolver",
+                            "default": "\"\""
+                        },
+                        "proxyServer": {
+                            "type": "string",
+                            "description": "Set the outbound proxy server; this switch only affects HTTP and HTTPS requests",
+                            "default": "\"\""
+                        },
+                        "clearCache": {
+                            "type": "boolean",
+                            "description": "Clear Chromium cache between each conversion",
+                            "default": "false"
+                        },
+                        "clearCookies": {
+                            "type": "boolean",
+                            "description": "Clear Chromium cookies between each conversion",
+                            "default": "false"
+                        },
+                        "disableJavaScript": {
+                            "type": "boolean",
+                            "description": "Disable JavaScript",
+                            "default": "false"
+                        },
+                        "disableRoutes": {
+                            "type": "boolean",
+                            "description": "Disable the routes",
+                            "default": "false"
+                        },
+                        "maxConcurrency": {
+                            "type": "number",
+                            "description": "Maximum number of simultaneous Chromium conversions",
+                            "default": "6"
+                        },
+                        "idleShutdownTimeout": {
+                            "type": "string",
+                            "description": "Auto-stop Chromium after this idle period; set to \"0s\" to disable",
+                            "default": "\"0s\""
+                        },
+                        "clearStorage": {
+                            "type": "boolean",
+                            "description": "Clear browser storage between each conversion",
+                            "default": "false"
+                        },
+                        "denyPrivateIps": {
+                            "type": "boolean",
+                            "description": "Reject Chromium navigations/sub-resources resolving to a non-public IP",
+                            "default": "false"
+                        },
+                        "denyPublicIps": {
+                            "type": "boolean",
+                            "description": "Reject Chromium navigations/sub-resources resolving to a public IP",
+                            "default": "false"
+                        },
+                        "enableEnvironmentProxy": {
+                            "type": "boolean",
+                            "description": "Route outbound Chromium traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
+                            "default": "false"
+                        }
+                    }
+                },
+                "libreOffice": {
+                    "type": "object",
+                    "properties": {
+                        "restartAfter": {
+                            "type": "number",
+                            "description": "Number of conversions after which LibreOffice will automatically restart",
+                            "default": "10"
+                        },
+                        "maxQueueSize": {
+                            "type": "number",
+                            "description": "Maximum request queue size for LibreOffice",
+                            "default": "0"
+                        },
+                        "autoStart": {
+                            "type": "boolean",
+                            "description": "Automatically launch LibreOffice upon initialization if set to true",
+                            "default": "false"
+                        },
+                        "startTimeout": {
+                            "type": "string",
+                            "description": "Maximum duration to wait for LibreOffice to start or restart",
+                            "default": "20s"
+                        },
+                        "disableRoutes": {
+                            "type": "boolean",
+                            "description": "Disable the route",
+                            "default": "false"
+                        },
+                        "idleShutdownTimeout": {
+                            "type": "string",
+                            "description": "Auto-stop LibreOffice after this idle period; set to \"0s\" to disable",
+                            "default": "\"0s\""
+                        },
+                        "allowList": {
+                            "type": "string",
+                            "description": "Set the allowed URLs for LibreOffice's outbound fetches using a regular expression",
+                            "default": "\"\""
+                        },
+                        "denyList": {
+                            "type": "string",
+                            "description": "Set the denied URLs for LibreOffice's outbound fetches using a regular expression",
+                            "default": "\"\""
+                        },
+                        "denyPrivateIps": {
+                            "type": "boolean",
+                            "description": "Reject LibreOffice outbound fetches resolving to a non-public IP",
+                            "default": "false"
+                        },
+                        "denyPublicIps": {
+                            "type": "boolean",
+                            "description": "Reject LibreOffice outbound fetches resolving to a public IP",
+                            "default": "false"
+                        },
+                        "enableEnvironmentProxy": {
+                            "type": "boolean",
+                            "description": "Route outbound LibreOffice traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
+                            "default": "false"
+                        }
+                    }
+                },
+                "pdf": {
+                    "type": "object",
+                    "properties": {
+                        "convertEngines": {
+                            "type": "string",
+                            "description": "Set the PDF conversion engines and their order",
+                            "default": "libreoffice-pdfengine"
+                        },
+                        "readMetadataEngines": {
+                            "type": "string",
+                            "description": "Set the PDF metadata-reading engines and their order",
+                            "default": "exiftool"
+                        },
+                        "writeMetadataEngines": {
+                            "type": "string",
+                            "description": "Set the PDF metadata-writing engines and their order",
+                            "default": "exiftool"
+                        },
+                        "disableRoutes": {
+                            "type": "boolean",
+                            "description": "Disable the routes",
+                            "default": "false"
+                        }
+                    }
+                },
+                "webhook": {
+                    "type": "object",
+                    "properties": {
+                        "allowList": {
+                            "type": "string",
+                            "description": "Set the allowed URLs for the webhook feature using a regular expression",
+                            "default": "\"\""
+                        },
+                        "denyList": {
+                            "type": "string",
+                            "description": "Set the denied URLs for the webhook feature using a regular expression",
+                            "default": "\"\""
+                        },
+                        "errorAllowList": {
+                            "type": "string",
+                            "description": "Set the allowed URLs in case of an error using a regular expression",
+                            "default": "\"\""
+                        },
+                        "errorDenyList": {
+                            "type": "string",
+                            "description": "Set the denied URLs in case of an error using a regular expression",
+                            "default": "\"\""
+                        },
+                        "maxRetry": {
+                            "type": "number",
+                            "description": "Set the maximum number of retries",
+                            "default": "4"
+                        },
+                        "retryMinWait": {
+                            "type": "string",
+                            "description": "Set the minimum duration to wait before trying to call the webhook again",
+                            "default": "1s"
+                        },
+                        "retryMaxWait": {
+                            "type": "string",
+                            "description": "Set the maximum duration to wait before trying to call the webhook again",
+                            "default": "30s"
+                        },
+                        "clientTimeout": {
+                            "type": "string",
+                            "description": "Set the time limit for requests to the webhook",
+                            "default": "30s"
+                        },
+                        "disable": {
+                            "type": "boolean",
+                            "description": "Disable the webhook feature",
+                            "default": "false"
+                        },
+                        "denyPrivateIps": {
+                            "type": "boolean",
+                            "description": "Reject webhook URLs (success, error, events) resolving to a non-public IP",
+                            "default": "false"
+                        },
+                        "denyPublicIps": {
+                            "type": "boolean",
+                            "description": "Reject webhook URLs resolving to a public IP",
+                            "default": "false"
+                        },
+                        "enableEnvironmentProxy": {
+                            "type": "boolean",
+                            "description": "Route outbound webhook traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
+                            "default": "false"
+                        }
+                    }
+                },
+                "prometheus": {
+                    "type": "object",
+                    "properties": {
+                        "collectInterval": {
+                            "type": "string",
+                            "description": "Set the interval for collecting modules' metrics",
+                            "default": "1s"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Set the namespace of modules' metrics",
+                            "default": "gotenberg"
+                        },
+                        "disableCollect": {
+                            "type": "boolean",
+                            "description": "Disable the collect of metrics",
+                            "default": "false"
+                        },
+                        "disableRouteTelemetry": {
+                            "type": "boolean",
+                            "description": "Disable telemetry for the /prometheus route",
+                            "default": "false"
+                        },
+                        "metricsPath": {
+                            "type": "string",
+                            "description": "Customise the Prometheus scrape endpoint path",
+                            "default": "\"\""
+                        }
+                    }
+                },
+                "openTelemetry": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable OpenTelemetry tracing/metrics/logging env vars below",
+                            "default": "false"
+                        },
+                        "tracesExporter": {
+                            "type": "string",
+                            "description": "Sets OTEL_TRACES_EXPORTER",
+                            "default": "\"\""
+                        },
+                        "metricsExporter": {
+                            "type": "string",
+                            "description": "Sets OTEL_METRICS_EXPORTER",
+                            "default": "\"\""
+                        },
+                        "logsExporter": {
+                            "type": "string",
+                            "description": "Sets OTEL_LOGS_EXPORTER",
+                            "default": "\"\""
+                        },
+                        "exporterOtlpEndpoint": {
+                            "type": "string",
+                            "description": "Sets OTEL_EXPORTER_OTLP_ENDPOINT",
+                            "default": "\"\""
+                        }
+                    }
+                },
+                "logging": {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "string",
+                            "description": "Specify the format of logging",
+                            "default": "auto"
+                        },
+                        "level": {
+                            "type": "string",
+                            "description": "Choose the level of logging detail",
+                            "default": "info"
+                        },
+                        "levelCase": {
+                            "type": "string",
+                            "description": "Set the level field casing in standard output",
+                            "default": "lower"
+                        },
+                        "fieldsPrefix": {
+                            "type": "string",
+                            "description": "Prepend a specified prefix to each field in the logs",
+                            "default": "\"\""
+                        },
+                        "enableGcpFields": {
+                            "type": "boolean",
+                            "description": "Use GCP Cloud Run-compatible structured log field names",
+                            "default": "false"
+                        }
+                    }
+                },
+                "shutdown": {
+                    "type": "object",
+                    "properties": {
+                        "duration": {
+                            "type": "string",
+                            "description": "Set the graceful shutdown duration",
+                            "default": "30s"
+                        }
+                    }
+                }
             }
-          }
         },
-        "chromium": {
-          "type": "object",
-          "properties": {
-            "restartAfter": {
-              "type": "number",
-              "description": "Number of conversions after which Chromium will auto-restart",
-              "default": "0"
-            },
-            "maxQueueSize": {
-              "type": "number",
-              "description": "Maximum request queue size for Chromium",
-              "default": "0"
-            },
-            "autoStart": {
-              "type": "boolean",
-              "description": "Automatically launch Chromium upon initialization if set to true",
-              "default": "false"
-            },
-            "startTimeout": {
-              "type": "string",
-              "description": "Maximum duration to wait for Chromium to start or restart",
-              "default": "20s"
-            },
-            "allowFileAccessFromFiles": {
-              "type": "boolean",
-              "description": "Allow file:// URIs to read other file:// URIs",
-              "default": "false"
-            },
-            "allowInsecureLocalhost": {
-              "type": "boolean",
-              "description": "Ignore TLS/SSL errors on localhost",
-              "default": "false"
-            },
-            "allowList": {
-              "type": "string",
-              "description": "Set the allowed URLs for Chromium using a regular expression - defaults to 'All'",
-              "default": "\"\""
-            },
-            "denyList": {
-              "type": "string",
-              "description": "Set the denied URLs for Chromium using a regular expression",
-              "default": "\"\""
-            },
-            "ignoreCertificateErrors": {
-              "type": "boolean",
-              "description": "Ignore the certificate errors",
-              "default": "false"
-            },
-            "disableWebSecurity": {
-              "type": "boolean",
-              "description": "Don't enforce the same-origin policy",
-              "default": "false"
-            },
-            "incognito": {
-              "type": "boolean",
-              "description": "Start Chromium with incognito mode",
-              "default": "false"
-            },
-            "hostResolverRules": {
-              "type": "string",
-              "description": "Set custom mappings to the host resolver",
-              "default": "\"\""
-            },
-            "proxyServer": {
-              "type": "string",
-              "description": "Set the outbound proxy server; this switch only affects HTTP and HTTPS requests",
-              "default": "\"\""
-            },
-            "clearCache": {
-              "type": "boolean",
-              "description": "Clear Chromium cache between each conversion",
-              "default": "false"
-            },
-            "clearCookies": {
-              "type": "boolean",
-              "description": "Clear Chromium cookies between each conversion",
-              "default": "false"
-            },
-            "disableJavaScript": {
-              "type": "boolean",
-              "description": "Disable JavaScript",
-              "default": "false"
-            },
-            "disableRoutes": {
-              "type": "boolean",
-              "description": "Disable the routes",
-              "default": "false"
+        "secret": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "description": "Common annotations for the SMTP, HIBP, Admin and Database secrets",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Common extra labels for the SMTP, HIBP, Admin and Database secrets",
+                    "default": {}
+                }
             }
-          }
         },
-        "libreOffice": {
-          "type": "object",
-          "properties": {
-            "restartAfter": {
-              "type": "number",
-              "description": "Number of conversions after which LibreOffice will automatically restart",
-              "default": "10"
-            },
-            "maxQueueSize": {
-              "type": "number",
-              "description": "Maximum request queue size for LibreOffice",
-              "default": "0"
-            },
-            "autoStart": {
-              "type": "boolean",
-              "description": "Automatically launch LibreOffice upon initialization if set to true",
-              "default": "false"
-            },
-            "startTimeout": {
-              "type": "string",
-              "description": "Maximum duration to wait for LibreOffice to start or restart",
-              "default": "20s"
-            },
-            "disableRoutes": {
-              "type": "boolean",
-              "description": "Disable the route",
-              "default": "false"
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable Ingress",
+                    "default": false
+                },
+                "className": {
+                    "type": "string",
+                    "description": "The IngressClass to use for the pod's ingress",
+                    "default": ""
+                },
+                "whitelist": {
+                    "type": "string",
+                    "description": "A comma-separated list of IP addresses to whitelist",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the Ingress resource",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "array",
+                    "description": "A list of hostnames and secret names to use for TLS",
+                    "default": [],
+                    "items": {}
+                },
+                "hosts": {
+                    "type": "array",
+                    "description": "A list of hosts for the Ingress resource",
+                    "default": [],
+                    "items": {}
+                }
             }
-          }
         },
-        "pdf": {
-          "type": "object",
-          "properties": {
-            "engines": {
-              "type": "string",
-              "description": "Set the PDF engines and their order - defaults to 'All'",
-              "default": "\"\""
-            },
-            "disableRoutes": {
-              "type": "boolean",
-              "description": "Disable the routes",
-              "default": "false"
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of service to create",
+                    "default": "ClusterIP"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "The port to use on the service",
+                    "default": "80"
+                },
+                "nodePort": {
+                    "type": "number",
+                    "description": "The Node port to use on the service",
+                    "default": "30080"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to add to the service",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "The external traffic policy for the service",
+                    "default": "Cluster"
+                },
+                "internalTrafficPolicy": {
+                    "type": "string",
+                    "description": "The internal traffic policy for the service",
+                    "default": "Cluster"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Define a static cluster IP for the service",
+                    "default": "\"\""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Set the Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerClass": {
+                    "type": "string",
+                    "description": "Define Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer source ranges",
+                    "default": [],
+                    "items": {}
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "Service External IPs",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
             }
-          }
         },
-        "webhook": {
-          "type": "object",
-          "properties": {
-            "allowList": {
-              "type": "string",
-              "description": "Set the allowed URLs for the webhook feature using a regular expression",
-              "default": "\"\""
-            },
-            "denyList": {
-              "type": "string",
-              "description": "Set the denied URLs for the webhook feature using a regular expression",
-              "default": "\"\""
-            },
-            "errorAllowList": {
-              "type": "string",
-              "description": "Set the allowed URLs in case of an error using a regular expression",
-              "default": "\"\""
-            },
-            "errorDenyList": {
-              "type": "string",
-              "description": "Set the denied URLs in case of an error using a regular expression",
-              "default": "\"\""
-            },
-            "maxRetry": {
-              "type": "number",
-              "description": "Set the maximum number of retries",
-              "default": "4"
-            },
-            "retryMinWait": {
-              "type": "string",
-              "description": "Set the minimum duration to wait before trying to call the webhook again",
-              "default": "1s"
-            },
-            "retryMaxWait": {
-              "type": "string",
-              "description": "Set the maximum duration to wait before trying to call the webhook again",
-              "default": "30s"
-            },
-            "clientTimeout": {
-              "type": "string",
-              "description": "Set the time limit for requests to the webhook",
-              "default": "30s"
-            },
-            "disable": {
-              "type": "boolean",
-              "description": "Disable the webhook feature",
-              "default": "false"
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create RBAC resources",
+                    "default": true
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Extra rules to add to the Role",
+                    "default": [],
+                    "items": {}
+                }
             }
-          }
         },
-        "prometheus": {
-          "type": "object",
-          "properties": {
-            "collectInterval": {
-              "type": "string",
-              "description": "Set the interval for collecting modules' metrics",
-              "default": "1s"
-            },
-            "namespace": {
-              "type": "string",
-              "description": "Set the namespace of modules' metrics",
-              "default": "gotenberg"
-            },
-            "disableCollect": {
-              "type": "boolean",
-              "description": "Disable the collect of metrics",
-              "default": "false"
-            },
-            "disableRouteLogging": {
-              "type": "boolean",
-              "description": "Disable the route logging",
-              "default": "false"
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether a service account should be created",
+                    "default": true
+                },
+                "automount": {
+                    "type": "boolean",
+                    "description": "Whether to automount the service account token",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the service account",
+                    "default": {}
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A custom name for the service account, otherwise gotenberg.fullname is used",
+                    "default": ""
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "A list of secrets mountable by this service account",
+                    "default": [],
+                    "items": {}
+                }
             }
-          }
         },
-        "logging": {
-          "type": "object",
-          "properties": {
-            "format": {
-              "type": "string",
-              "description": "Specify the format of logging",
-              "default": "auto"
-            },
-            "level": {
-              "type": "string",
-              "description": "Choose the level of logging detail",
-              "default": "info"
-            },
-            "fieldsPrefix": {
-              "type": "string",
-              "description": "Prepend a specified prefix to each field in the logs",
-              "default": "\"\""
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable the use of liveness probes",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Configure the initial delay seconds for the liveness probe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Configure the initial delay seconds for the liveness probe",
+                    "default": 1
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Configure the seconds for each period of the liveness probe",
+                    "default": 10
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Configure the success threshold for the liveness probe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Configure the failure threshold for the liveness probe",
+                    "default": 10
+                }
             }
-          }
         },
-        "shutdown": {
-          "type": "object",
-          "properties": {
-            "duration": {
-              "type": "string",
-              "description": "Set the graceful shutdown duration",
-              "default": "30s"
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable the use of readiness probes",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Configure the initial delay seconds for the readiness probe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Configure the initial delay seconds for the readiness probe",
+                    "default": 1
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Configure the seconds for each period of the readiness probe",
+                    "default": 10
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Configure the success threshold for the readiness probe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Configure the failure threshold for the readiness probe",
+                    "default": 3
+                }
             }
-          }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable the use of readiness probes",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Configure the initial delay seconds for the startup probe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Configure the initial delay seconds for the startup probe",
+                    "default": 1
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Configure the seconds for each period of the startup probe",
+                    "default": 10
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Configure the success threshold for the startup probe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Configure the failure threshold for the startup probe",
+                    "default": 10
+                }
+            }
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the pod disruption budget",
+                    "default": "true"
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "The minimum amount of pods which need to be available",
+                    "default": "1"
+                }
+            }
+        },
+        "replicas": {
+            "type": "number",
+            "description": "The amount of replicas Gotenberg deployment should create",
+            "default": 1
+        },
+        "resources": {
+            "type": "object",
+            "description": "The resource limits/requests for the Gotenberg pod",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables for the Gotenberg pod, e.g. for TZ",
+            "default": [],
+            "items": {}
+        },
+        "volumes": {
+            "type": "array",
+            "description": "Define volumes for the Gotenberg pod",
+            "default": [],
+            "items": {}
+        },
+        "volumeMounts": {
+            "type": "array",
+            "description": "Define volumeMounts for the Gotenberg pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Define initContainers for the main Gotenberg server",
+            "default": [],
+            "items": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "strategy": {
+            "type": "object",
+            "description": "Specify a deployment strategy for the Gotenberg pod",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Extra annotations for the Gotenberg pod",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for the Gotenberg pod",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "The name of an existing PriorityClass",
+            "default": ""
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "description": "Security context settings for the Gotenberg pod",
+            "default": {}
+        },
+        "securityContext": {
+            "type": "object",
+            "description": "General security context settings for",
+            "default": {}
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable the HorizontalPodAutoscaler",
+                    "default": "false"
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "The minimum replicas to autoscale to",
+                    "default": "1"
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "The maximum replicas to autoscale to",
+                    "default": "10"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "number",
+                    "description": "The CPU utilization at which to start autoscaling",
+                    "default": "80"
+                }
+            }
         }
-      }
-    },
-    "secret": {
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "type": "object",
-          "description": "Common annotations for the SMTP, HIBP, Admin and Database secrets",
-          "default": {}
-        },
-        "labels": {
-          "type": "object",
-          "description": "Common extra labels for the SMTP, HIBP, Admin and Database secrets",
-          "default": {}
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether to enable Ingress",
-          "default": false
-        },
-        "className": {
-          "type": "string",
-          "description": "The IngressClass to use for the pod's ingress",
-          "default": ""
-        },
-        "whitelist": {
-          "type": "string",
-          "description": "A comma-separated list of IP addresses to whitelist",
-          "default": ""
-        },
-        "annotations": {
-          "type": "object",
-          "description": "Annotations for the Ingress resource",
-          "default": {}
-        },
-        "tls": {
-          "type": "array",
-          "description": "A list of hostnames and secret names to use for TLS",
-          "default": [],
-          "items": {}
-        },
-        "hosts": {
-          "type": "array",
-          "description": "A list of hosts for the Ingress resource",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "service": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The type of service to create",
-          "default": "ClusterIP"
-        },
-        "port": {
-          "type": "number",
-          "description": "The port to use on the service",
-          "default": "80"
-        },
-        "nodePort": {
-          "type": "number",
-          "description": "The Node port to use on the service",
-          "default": "30080"
-        },
-        "extraPorts": {
-          "type": "array",
-          "description": "Extra ports to add to the service",
-          "default": [],
-          "items": {}
-        },
-        "externalTrafficPolicy": {
-          "type": "string",
-          "description": "The external traffic policy for the service",
-          "default": "Cluster"
-        },
-        "internalTrafficPolicy": {
-          "type": "string",
-          "description": "The internal traffic policy for the service",
-          "default": "Cluster"
-        },
-        "clusterIP": {
-          "type": "string",
-          "description": "Define a static cluster IP for the service",
-          "default": "\"\""
-        },
-        "loadBalancerIP": {
-          "type": "string",
-          "description": "Set the Load Balancer IP",
-          "default": ""
-        },
-        "loadBalancerClass": {
-          "type": "string",
-          "description": "Define Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)",
-          "default": ""
-        },
-        "loadBalancerSourceRanges": {
-          "type": "array",
-          "description": "Service Load Balancer source ranges",
-          "default": [],
-          "items": {}
-        },
-        "externalIPs": {
-          "type": "array",
-          "description": "Service External IPs",
-          "default": [],
-          "items": {}
-        },
-        "sessionAffinity": {
-          "type": "string",
-          "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
-          "default": "None"
-        },
-        "sessionAffinityConfig": {
-          "type": "object",
-          "description": "Additional settings for the sessionAffinity",
-          "default": {}
-        }
-      }
-    },
-    "rbac": {
-      "type": "object",
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Whether to create RBAC resources",
-          "default": true
-        },
-        "rules": {
-          "type": "array",
-          "description": "Extra rules to add to the Role",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Whether a service account should be created",
-          "default": true
-        },
-        "automount": {
-          "type": "boolean",
-          "description": "Whether to automount the service account token",
-          "default": false
-        },
-        "annotations": {
-          "type": "object",
-          "description": "Annotations to add to the service account",
-          "default": {}
-        },
-        "name": {
-          "type": "string",
-          "description": "A custom name for the service account, otherwise gotenberg.fullname is used",
-          "default": ""
-        },
-        "secrets": {
-          "type": "array",
-          "description": "A list of secrets mountable by this service account",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "livenessProbe": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable or disable the use of liveness probes",
-          "default": false
-        },
-        "initialDelaySeconds": {
-          "type": "number",
-          "description": "Configure the initial delay seconds for the liveness probe",
-          "default": 5
-        },
-        "timeoutSeconds": {
-          "type": "number",
-          "description": "Configure the initial delay seconds for the liveness probe",
-          "default": 1
-        },
-        "periodSeconds": {
-          "type": "number",
-          "description": "Configure the seconds for each period of the liveness probe",
-          "default": 10
-        },
-        "successThreshold": {
-          "type": "number",
-          "description": "Configure the success threshold for the liveness probe",
-          "default": 1
-        },
-        "failureThreshold": {
-          "type": "number",
-          "description": "Configure the failure threshold for the liveness probe",
-          "default": 10
-        }
-      }
-    },
-    "readinessProbe": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable or disable the use of readiness probes",
-          "default": false
-        },
-        "initialDelaySeconds": {
-          "type": "number",
-          "description": "Configure the initial delay seconds for the readiness probe",
-          "default": 5
-        },
-        "timeoutSeconds": {
-          "type": "number",
-          "description": "Configure the initial delay seconds for the readiness probe",
-          "default": 1
-        },
-        "periodSeconds": {
-          "type": "number",
-          "description": "Configure the seconds for each period of the readiness probe",
-          "default": 10
-        },
-        "successThreshold": {
-          "type": "number",
-          "description": "Configure the success threshold for the readiness probe",
-          "default": 1
-        },
-        "failureThreshold": {
-          "type": "number",
-          "description": "Configure the failure threshold for the readiness probe",
-          "default": 3
-        }
-      }
-    },
-    "startupProbe": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable or disable the use of readiness probes",
-          "default": false
-        },
-        "initialDelaySeconds": {
-          "type": "number",
-          "description": "Configure the initial delay seconds for the startup probe",
-          "default": 5
-        },
-        "timeoutSeconds": {
-          "type": "number",
-          "description": "Configure the initial delay seconds for the startup probe",
-          "default": 1
-        },
-        "periodSeconds": {
-          "type": "number",
-          "description": "Configure the seconds for each period of the startup probe",
-          "default": 10
-        },
-        "successThreshold": {
-          "type": "number",
-          "description": "Configure the success threshold for the startup probe",
-          "default": 1
-        },
-        "failureThreshold": {
-          "type": "number",
-          "description": "Configure the failure threshold for the startup probe",
-          "default": 10
-        }
-      }
-    },
-    "podDisruptionBudget": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable the pod disruption budget",
-          "default": "true"
-        },
-        "minAvailable": {
-          "type": "number",
-          "description": "The minimum amount of pods which need to be available",
-          "default": "1"
-        }
-      }
-    },
-    "replicas": {
-      "type": "number",
-      "description": "The amount of replicas Gotenberg deployment should create",
-      "default": 1
-    },
-    "resources": {
-      "type": "object",
-      "description": "The resource limits/requests for the Gotenberg pod",
-      "default": {}
-    },
-    "volumes": {
-      "type": "array",
-      "description": "Define volumes for the Gotenberg pod",
-      "default": [],
-      "items": {}
-    },
-    "volumeMounts": {
-      "type": "array",
-      "description": "Define volumeMounts for the Gotenberg pod",
-      "default": [],
-      "items": {}
-    },
-    "initContainers": {
-      "type": "array",
-      "description": "Define initContainers for the main Gotenberg server",
-      "default": [],
-      "items": {}
-    },
-    "nodeSelector": {
-      "type": "object",
-      "description": "Node labels for pod assignment",
-      "default": {}
-    },
-    "tolerations": {
-      "type": "array",
-      "description": "Tolerations for pod assignment",
-      "default": [],
-      "items": {}
-    },
-    "affinity": {
-      "type": "object",
-      "description": "Affinity for pod assignment",
-      "default": {}
-    },
-    "strategy": {
-      "type": "object",
-      "description": "Specify a deployment strategy for the Gotenberg pod",
-      "default": {}
-    },
-    "podAnnotations": {
-      "type": "object",
-      "description": "Extra annotations for the Gotenberg pod",
-      "default": {}
-    },
-    "podLabels": {
-      "type": "object",
-      "description": "Extra labels for the Gotenberg pod",
-      "default": {}
-    },
-    "priorityClassName": {
-      "type": "string",
-      "description": "The name of an existing PriorityClass",
-      "default": ""
-    },
-    "podSecurityContext": {
-      "type": "object",
-      "description": "Security context settings for the Gotenberg pod",
-      "default": {}
-    },
-    "securityContext": {
-      "type": "object",
-      "description": "General security context settings for",
-      "default": {}
-    },
-    "autoscaling": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable or disable the HorizontalPodAutoscaler",
-          "default": "false"
-        },
-        "minReplicas": {
-          "type": "number",
-          "description": "The minimum replicas to autoscale to",
-          "default": "1"
-        },
-        "maxReplicas": {
-          "type": "number",
-          "description": "The maximum replicas to autoscale to",
-          "default": "10"
-        },
-        "targetCPUUtilizationPercentage": {
-          "type": "number",
-          "description": "The CPU utilization at which to start autoscaling",
-          "default": "80"
-        }
-      }
     }
-  }
 }

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -1,924 +1,924 @@
 {
-    "title": "Chart Values",
-    "type": "object",
-    "properties": {
-        "image": {
-            "type": "object",
-            "properties": {
-                "registry": {
-                    "type": "string",
-                    "description": "The Docker registry to pull the image from",
-                    "default": "docker.io"
-                },
-                "repository": {
-                    "type": "string",
-                    "description": "The registry repository to pull the image from",
-                    "default": "gotenberg/gotenberg"
-                },
-                "tag": {
-                    "type": "string",
-                    "description": "The image tag to pull",
-                    "default": "8.36.0"
-                },
-                "digest": {
-                    "type": "string",
-                    "description": "The image digest to pull",
-                    "default": ""
-                },
-                "pullPolicy": {
-                    "type": "string",
-                    "description": "The Kubernetes image pull policy",
-                    "default": "IfNotPresent"
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "description": "A list of secrets to use for pulling images from private registries",
-                    "default": [],
-                    "items": {}
-                }
-            }
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "The Docker registry to pull the image from",
+          "default": "docker.io"
         },
-        "nameOverride": {
-            "type": "string",
-            "description": "String to partially override gotenberg.fullname",
-            "default": ""
+        "repository": {
+          "type": "string",
+          "description": "The registry repository to pull the image from",
+          "default": "gotenberg/gotenberg"
         },
-        "fullnameOverride": {
-            "type": "string",
-            "description": "String to fully override gotenberg.fullname",
-            "default": ""
+        "tag": {
+          "type": "string",
+          "description": "The image tag to pull",
+          "default": "8.36.0"
         },
-        "gotenberg": {
-            "type": "object",
-            "properties": {
-                "api": {
-                    "type": "object",
-                    "properties": {
-                        "port": {
-                            "type": "number",
-                            "description": "The port the API should listen on",
-                            "default": "3000"
-                        },
-                        "tlsCertFile": {
-                            "type": "string",
-                            "description": "Disable health check logging",
-                            "default": "\"\""
-                        },
-                        "tlsKeyFile": {
-                            "type": "string",
-                            "description": "Disable health check logging",
-                            "default": "\"\""
-                        },
-                        "startTimeout": {
-                            "type": "string",
-                            "description": "Set the time limit for the API to start",
-                            "default": "30s"
-                        },
-                        "timeout": {
-                            "type": "string",
-                            "description": "Set the time limit for requests",
-                            "default": "30s"
-                        },
-                        "rootPath": {
-                            "type": "string",
-                            "description": "Set the root path of the API",
-                            "default": "\"/\""
-                        },
-                        "correlationIdHeader": {
-                            "type": "string",
-                            "description": "Set the header name to use for identifying requests",
-                            "default": "\"\""
-                        },
-                        "disableHealthCheckLogging": {
-                            "type": "boolean",
-                            "description": "Disable health check route telemetry",
-                            "default": "false"
-                        },
-                        "disableRootRouteTelemetry": {
-                            "type": "boolean",
-                            "description": "Disable telemetry for the root (\"/\") route",
-                            "default": "false"
-                        },
-                        "disableDebugRouteTelemetry": {
-                            "type": "boolean",
-                            "description": "Disable telemetry for the /debug route",
-                            "default": "false"
-                        },
-                        "disableVersionRouteTelemetry": {
-                            "type": "boolean",
-                            "description": "Disable telemetry for the /version route",
-                            "default": "false"
-                        },
-                        "bodyLimit": {
-                            "type": "string",
-                            "description": "Set a cap on multipart/form-data request size, e.g. \"5MB\"",
-                            "default": "\"\""
-                        },
-                        "bindIp": {
-                            "type": "string",
-                            "description": "Bind the API to a specific IP address",
-                            "default": "0.0.0.0"
-                        },
-                        "enableDebugRoute": {
-                            "type": "boolean",
-                            "description": "Expose the /debug route with full instance configuration",
-                            "default": "false"
-                        },
-                        "enableOidcAuth": {
-                            "type": "boolean",
-                            "description": "Enable OIDC bearer token authentication (mutually exclusive with basicAuth)",
-                            "default": "false"
-                        }
-                    }
-                },
-                "basicAuth": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable basic authentication",
-                            "default": "false"
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "Set a username for HTTP Basic Auth",
-                            "default": "\"\""
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "Set a password for HTTP Basic Auth",
-                            "default": "\"\""
-                        },
-                        "existingSecret": {
-                            "type": "string",
-                            "description": "The name of an existing `basic-auth` secret",
-                            "default": "\"\""
-                        }
-                    }
-                },
-                "chromium": {
-                    "type": "object",
-                    "properties": {
-                        "restartAfter": {
-                            "type": "number",
-                            "description": "Number of conversions after which Chromium will auto-restart",
-                            "default": "0"
-                        },
-                        "maxQueueSize": {
-                            "type": "number",
-                            "description": "Maximum request queue size for Chromium",
-                            "default": "0"
-                        },
-                        "autoStart": {
-                            "type": "boolean",
-                            "description": "Automatically launch Chromium upon initialization if set to true",
-                            "default": "false"
-                        },
-                        "startTimeout": {
-                            "type": "string",
-                            "description": "Maximum duration to wait for Chromium to start or restart",
-                            "default": "20s"
-                        },
-                        "allowFileAccessFromFiles": {
-                            "type": "boolean",
-                            "description": "Allow file:// URIs to read other file:// URIs",
-                            "default": "false"
-                        },
-                        "allowInsecureLocalhost": {
-                            "type": "boolean",
-                            "description": "Ignore TLS/SSL errors on localhost",
-                            "default": "false"
-                        },
-                        "allowList": {
-                            "type": "string",
-                            "description": "Set the allowed URLs for Chromium using a regular expression - defaults to 'All'",
-                            "default": "\"\""
-                        },
-                        "denyList": {
-                            "type": "string",
-                            "description": "Set the denied URLs for Chromium using a regular expression",
-                            "default": "\"\""
-                        },
-                        "ignoreCertificateErrors": {
-                            "type": "boolean",
-                            "description": "Ignore the certificate errors",
-                            "default": "false"
-                        },
-                        "disableWebSecurity": {
-                            "type": "boolean",
-                            "description": "Don't enforce the same-origin policy",
-                            "default": "false"
-                        },
-                        "hostResolverRules": {
-                            "type": "string",
-                            "description": "Set custom mappings to the host resolver",
-                            "default": "\"\""
-                        },
-                        "proxyServer": {
-                            "type": "string",
-                            "description": "Set the outbound proxy server; this switch only affects HTTP and HTTPS requests",
-                            "default": "\"\""
-                        },
-                        "clearCache": {
-                            "type": "boolean",
-                            "description": "Clear Chromium cache between each conversion",
-                            "default": "false"
-                        },
-                        "clearCookies": {
-                            "type": "boolean",
-                            "description": "Clear Chromium cookies between each conversion",
-                            "default": "false"
-                        },
-                        "disableJavaScript": {
-                            "type": "boolean",
-                            "description": "Disable JavaScript",
-                            "default": "false"
-                        },
-                        "disableRoutes": {
-                            "type": "boolean",
-                            "description": "Disable the routes",
-                            "default": "false"
-                        },
-                        "maxConcurrency": {
-                            "type": "number",
-                            "description": "Maximum number of simultaneous Chromium conversions",
-                            "default": "6"
-                        },
-                        "idleShutdownTimeout": {
-                            "type": "string",
-                            "description": "Auto-stop Chromium after this idle period; set to \"0s\" to disable",
-                            "default": "\"0s\""
-                        },
-                        "clearStorage": {
-                            "type": "boolean",
-                            "description": "Clear browser storage between each conversion",
-                            "default": "false"
-                        },
-                        "denyPrivateIps": {
-                            "type": "boolean",
-                            "description": "Reject Chromium navigations/sub-resources resolving to a non-public IP",
-                            "default": "false"
-                        },
-                        "denyPublicIps": {
-                            "type": "boolean",
-                            "description": "Reject Chromium navigations/sub-resources resolving to a public IP",
-                            "default": "false"
-                        },
-                        "enableEnvironmentProxy": {
-                            "type": "boolean",
-                            "description": "Route outbound Chromium traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
-                            "default": "false"
-                        }
-                    }
-                },
-                "libreOffice": {
-                    "type": "object",
-                    "properties": {
-                        "restartAfter": {
-                            "type": "number",
-                            "description": "Number of conversions after which LibreOffice will automatically restart",
-                            "default": "10"
-                        },
-                        "maxQueueSize": {
-                            "type": "number",
-                            "description": "Maximum request queue size for LibreOffice",
-                            "default": "0"
-                        },
-                        "autoStart": {
-                            "type": "boolean",
-                            "description": "Automatically launch LibreOffice upon initialization if set to true",
-                            "default": "false"
-                        },
-                        "startTimeout": {
-                            "type": "string",
-                            "description": "Maximum duration to wait for LibreOffice to start or restart",
-                            "default": "20s"
-                        },
-                        "disableRoutes": {
-                            "type": "boolean",
-                            "description": "Disable the route",
-                            "default": "false"
-                        },
-                        "idleShutdownTimeout": {
-                            "type": "string",
-                            "description": "Auto-stop LibreOffice after this idle period; set to \"0s\" to disable",
-                            "default": "\"0s\""
-                        },
-                        "allowList": {
-                            "type": "string",
-                            "description": "Set the allowed URLs for LibreOffice's outbound fetches using a regular expression",
-                            "default": "\"\""
-                        },
-                        "denyList": {
-                            "type": "string",
-                            "description": "Set the denied URLs for LibreOffice's outbound fetches using a regular expression",
-                            "default": "\"\""
-                        },
-                        "denyPrivateIps": {
-                            "type": "boolean",
-                            "description": "Reject LibreOffice outbound fetches resolving to a non-public IP",
-                            "default": "false"
-                        },
-                        "denyPublicIps": {
-                            "type": "boolean",
-                            "description": "Reject LibreOffice outbound fetches resolving to a public IP",
-                            "default": "false"
-                        },
-                        "enableEnvironmentProxy": {
-                            "type": "boolean",
-                            "description": "Route outbound LibreOffice traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
-                            "default": "false"
-                        }
-                    }
-                },
-                "pdf": {
-                    "type": "object",
-                    "properties": {
-                        "convertEngines": {
-                            "type": "string",
-                            "description": "Set the PDF conversion engines and their order",
-                            "default": "libreoffice-pdfengine"
-                        },
-                        "readMetadataEngines": {
-                            "type": "string",
-                            "description": "Set the PDF metadata-reading engines and their order",
-                            "default": "exiftool"
-                        },
-                        "writeMetadataEngines": {
-                            "type": "string",
-                            "description": "Set the PDF metadata-writing engines and their order",
-                            "default": "exiftool"
-                        },
-                        "disableRoutes": {
-                            "type": "boolean",
-                            "description": "Disable the routes",
-                            "default": "false"
-                        }
-                    }
-                },
-                "webhook": {
-                    "type": "object",
-                    "properties": {
-                        "allowList": {
-                            "type": "string",
-                            "description": "Set the allowed URLs for the webhook feature using a regular expression",
-                            "default": "\"\""
-                        },
-                        "denyList": {
-                            "type": "string",
-                            "description": "Set the denied URLs for the webhook feature using a regular expression",
-                            "default": "\"\""
-                        },
-                        "errorAllowList": {
-                            "type": "string",
-                            "description": "Set the allowed URLs in case of an error using a regular expression",
-                            "default": "\"\""
-                        },
-                        "errorDenyList": {
-                            "type": "string",
-                            "description": "Set the denied URLs in case of an error using a regular expression",
-                            "default": "\"\""
-                        },
-                        "maxRetry": {
-                            "type": "number",
-                            "description": "Set the maximum number of retries",
-                            "default": "4"
-                        },
-                        "retryMinWait": {
-                            "type": "string",
-                            "description": "Set the minimum duration to wait before trying to call the webhook again",
-                            "default": "1s"
-                        },
-                        "retryMaxWait": {
-                            "type": "string",
-                            "description": "Set the maximum duration to wait before trying to call the webhook again",
-                            "default": "30s"
-                        },
-                        "clientTimeout": {
-                            "type": "string",
-                            "description": "Set the time limit for requests to the webhook",
-                            "default": "30s"
-                        },
-                        "disable": {
-                            "type": "boolean",
-                            "description": "Disable the webhook feature",
-                            "default": "false"
-                        },
-                        "denyPrivateIps": {
-                            "type": "boolean",
-                            "description": "Reject webhook URLs (success, error, events) resolving to a non-public IP",
-                            "default": "false"
-                        },
-                        "denyPublicIps": {
-                            "type": "boolean",
-                            "description": "Reject webhook URLs resolving to a public IP",
-                            "default": "false"
-                        },
-                        "enableEnvironmentProxy": {
-                            "type": "boolean",
-                            "description": "Route outbound webhook traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
-                            "default": "false"
-                        }
-                    }
-                },
-                "prometheus": {
-                    "type": "object",
-                    "properties": {
-                        "collectInterval": {
-                            "type": "string",
-                            "description": "Set the interval for collecting modules' metrics",
-                            "default": "1s"
-                        },
-                        "namespace": {
-                            "type": "string",
-                            "description": "Set the namespace of modules' metrics",
-                            "default": "gotenberg"
-                        },
-                        "disableCollect": {
-                            "type": "boolean",
-                            "description": "Disable the collect of metrics",
-                            "default": "false"
-                        },
-                        "disableRouteTelemetry": {
-                            "type": "boolean",
-                            "description": "Disable telemetry for the /prometheus route",
-                            "default": "false"
-                        },
-                        "metricsPath": {
-                            "type": "string",
-                            "description": "Customise the Prometheus scrape endpoint path",
-                            "default": "\"\""
-                        }
-                    }
-                },
-                "openTelemetry": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable OpenTelemetry tracing/metrics/logging env vars below",
-                            "default": "false"
-                        },
-                        "tracesExporter": {
-                            "type": "string",
-                            "description": "Sets OTEL_TRACES_EXPORTER",
-                            "default": "\"\""
-                        },
-                        "metricsExporter": {
-                            "type": "string",
-                            "description": "Sets OTEL_METRICS_EXPORTER",
-                            "default": "\"\""
-                        },
-                        "logsExporter": {
-                            "type": "string",
-                            "description": "Sets OTEL_LOGS_EXPORTER",
-                            "default": "\"\""
-                        },
-                        "exporterOtlpEndpoint": {
-                            "type": "string",
-                            "description": "Sets OTEL_EXPORTER_OTLP_ENDPOINT",
-                            "default": "\"\""
-                        }
-                    }
-                },
-                "logging": {
-                    "type": "object",
-                    "properties": {
-                        "format": {
-                            "type": "string",
-                            "description": "Specify the format of logging",
-                            "default": "auto"
-                        },
-                        "level": {
-                            "type": "string",
-                            "description": "Choose the level of logging detail",
-                            "default": "info"
-                        },
-                        "levelCase": {
-                            "type": "string",
-                            "description": "Set the level field casing in standard output",
-                            "default": "lower"
-                        },
-                        "fieldsPrefix": {
-                            "type": "string",
-                            "description": "Prepend a specified prefix to each field in the logs",
-                            "default": "\"\""
-                        },
-                        "enableGcpFields": {
-                            "type": "boolean",
-                            "description": "Use GCP Cloud Run-compatible structured log field names",
-                            "default": "false"
-                        }
-                    }
-                },
-                "shutdown": {
-                    "type": "object",
-                    "properties": {
-                        "duration": {
-                            "type": "string",
-                            "description": "Set the graceful shutdown duration",
-                            "default": "30s"
-                        }
-                    }
-                }
-            }
+        "digest": {
+          "type": "string",
+          "description": "The image digest to pull",
+          "default": ""
         },
-        "secret": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "description": "Common annotations for the SMTP, HIBP, Admin and Database secrets",
-                    "default": {}
-                },
-                "labels": {
-                    "type": "object",
-                    "description": "Common extra labels for the SMTP, HIBP, Admin and Database secrets",
-                    "default": {}
-                }
-            }
+        "pullPolicy": {
+          "type": "string",
+          "description": "The Kubernetes image pull policy",
+          "default": "IfNotPresent"
         },
-        "ingress": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Whether to enable Ingress",
-                    "default": false
-                },
-                "className": {
-                    "type": "string",
-                    "description": "The IngressClass to use for the pod's ingress",
-                    "default": ""
-                },
-                "whitelist": {
-                    "type": "string",
-                    "description": "A comma-separated list of IP addresses to whitelist",
-                    "default": ""
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations for the Ingress resource",
-                    "default": {}
-                },
-                "tls": {
-                    "type": "array",
-                    "description": "A list of hostnames and secret names to use for TLS",
-                    "default": [],
-                    "items": {}
-                },
-                "hosts": {
-                    "type": "array",
-                    "description": "A list of hosts for the Ingress resource",
-                    "default": [],
-                    "items": {}
-                }
-            }
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "description": "The type of service to create",
-                    "default": "ClusterIP"
-                },
-                "port": {
-                    "type": "number",
-                    "description": "The port to use on the service",
-                    "default": "80"
-                },
-                "nodePort": {
-                    "type": "number",
-                    "description": "The Node port to use on the service",
-                    "default": "30080"
-                },
-                "extraPorts": {
-                    "type": "array",
-                    "description": "Extra ports to add to the service",
-                    "default": [],
-                    "items": {}
-                },
-                "externalTrafficPolicy": {
-                    "type": "string",
-                    "description": "The external traffic policy for the service",
-                    "default": "Cluster"
-                },
-                "internalTrafficPolicy": {
-                    "type": "string",
-                    "description": "The internal traffic policy for the service",
-                    "default": "Cluster"
-                },
-                "clusterIP": {
-                    "type": "string",
-                    "description": "Define a static cluster IP for the service",
-                    "default": "\"\""
-                },
-                "loadBalancerIP": {
-                    "type": "string",
-                    "description": "Set the Load Balancer IP",
-                    "default": ""
-                },
-                "loadBalancerClass": {
-                    "type": "string",
-                    "description": "Define Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)",
-                    "default": ""
-                },
-                "loadBalancerSourceRanges": {
-                    "type": "array",
-                    "description": "Service Load Balancer source ranges",
-                    "default": [],
-                    "items": {}
-                },
-                "externalIPs": {
-                    "type": "array",
-                    "description": "Service External IPs",
-                    "default": [],
-                    "items": {}
-                },
-                "sessionAffinity": {
-                    "type": "string",
-                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
-                    "default": "None"
-                },
-                "sessionAffinityConfig": {
-                    "type": "object",
-                    "description": "Additional settings for the sessionAffinity",
-                    "default": {}
-                }
-            }
-        },
-        "rbac": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Whether to create RBAC resources",
-                    "default": true
-                },
-                "rules": {
-                    "type": "array",
-                    "description": "Extra rules to add to the Role",
-                    "default": [],
-                    "items": {}
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Whether a service account should be created",
-                    "default": true
-                },
-                "automount": {
-                    "type": "boolean",
-                    "description": "Whether to automount the service account token",
-                    "default": false
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations to add to the service account",
-                    "default": {}
-                },
-                "name": {
-                    "type": "string",
-                    "description": "A custom name for the service account, otherwise gotenberg.fullname is used",
-                    "default": ""
-                },
-                "secrets": {
-                    "type": "array",
-                    "description": "A list of secrets mountable by this service account",
-                    "default": [],
-                    "items": {}
-                }
-            }
-        },
-        "livenessProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable or disable the use of liveness probes",
-                    "default": false
-                },
-                "initialDelaySeconds": {
-                    "type": "number",
-                    "description": "Configure the initial delay seconds for the liveness probe",
-                    "default": 5
-                },
-                "timeoutSeconds": {
-                    "type": "number",
-                    "description": "Configure the initial delay seconds for the liveness probe",
-                    "default": 1
-                },
-                "periodSeconds": {
-                    "type": "number",
-                    "description": "Configure the seconds for each period of the liveness probe",
-                    "default": 10
-                },
-                "successThreshold": {
-                    "type": "number",
-                    "description": "Configure the success threshold for the liveness probe",
-                    "default": 1
-                },
-                "failureThreshold": {
-                    "type": "number",
-                    "description": "Configure the failure threshold for the liveness probe",
-                    "default": 10
-                }
-            }
-        },
-        "readinessProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable or disable the use of readiness probes",
-                    "default": false
-                },
-                "initialDelaySeconds": {
-                    "type": "number",
-                    "description": "Configure the initial delay seconds for the readiness probe",
-                    "default": 5
-                },
-                "timeoutSeconds": {
-                    "type": "number",
-                    "description": "Configure the initial delay seconds for the readiness probe",
-                    "default": 1
-                },
-                "periodSeconds": {
-                    "type": "number",
-                    "description": "Configure the seconds for each period of the readiness probe",
-                    "default": 10
-                },
-                "successThreshold": {
-                    "type": "number",
-                    "description": "Configure the success threshold for the readiness probe",
-                    "default": 1
-                },
-                "failureThreshold": {
-                    "type": "number",
-                    "description": "Configure the failure threshold for the readiness probe",
-                    "default": 3
-                }
-            }
-        },
-        "startupProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable or disable the use of readiness probes",
-                    "default": false
-                },
-                "initialDelaySeconds": {
-                    "type": "number",
-                    "description": "Configure the initial delay seconds for the startup probe",
-                    "default": 5
-                },
-                "timeoutSeconds": {
-                    "type": "number",
-                    "description": "Configure the initial delay seconds for the startup probe",
-                    "default": 1
-                },
-                "periodSeconds": {
-                    "type": "number",
-                    "description": "Configure the seconds for each period of the startup probe",
-                    "default": 10
-                },
-                "successThreshold": {
-                    "type": "number",
-                    "description": "Configure the success threshold for the startup probe",
-                    "default": 1
-                },
-                "failureThreshold": {
-                    "type": "number",
-                    "description": "Configure the failure threshold for the startup probe",
-                    "default": 10
-                }
-            }
-        },
-        "podDisruptionBudget": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable the pod disruption budget",
-                    "default": "true"
-                },
-                "minAvailable": {
-                    "type": "number",
-                    "description": "The minimum amount of pods which need to be available",
-                    "default": "1"
-                }
-            }
-        },
-        "replicas": {
-            "type": "number",
-            "description": "The amount of replicas Gotenberg deployment should create",
-            "default": 1
-        },
-        "resources": {
-            "type": "object",
-            "description": "The resource limits/requests for the Gotenberg pod",
-            "default": {}
-        },
-        "extraEnvVars": {
-            "type": "array",
-            "description": "Extra environment variables for the Gotenberg pod, e.g. for TZ",
-            "default": [],
-            "items": {}
-        },
-        "volumes": {
-            "type": "array",
-            "description": "Define volumes for the Gotenberg pod",
-            "default": [],
-            "items": {}
-        },
-        "volumeMounts": {
-            "type": "array",
-            "description": "Define volumeMounts for the Gotenberg pod",
-            "default": [],
-            "items": {}
-        },
-        "initContainers": {
-            "type": "array",
-            "description": "Define initContainers for the main Gotenberg server",
-            "default": [],
-            "items": {}
-        },
-        "nodeSelector": {
-            "type": "object",
-            "description": "Node labels for pod assignment",
-            "default": {}
-        },
-        "tolerations": {
-            "type": "array",
-            "description": "Tolerations for pod assignment",
-            "default": [],
-            "items": {}
-        },
-        "affinity": {
-            "type": "object",
-            "description": "Affinity for pod assignment",
-            "default": {}
-        },
-        "strategy": {
-            "type": "object",
-            "description": "Specify a deployment strategy for the Gotenberg pod",
-            "default": {}
-        },
-        "podAnnotations": {
-            "type": "object",
-            "description": "Extra annotations for the Gotenberg pod",
-            "default": {}
-        },
-        "podLabels": {
-            "type": "object",
-            "description": "Extra labels for the Gotenberg pod",
-            "default": {}
-        },
-        "priorityClassName": {
-            "type": "string",
-            "description": "The name of an existing PriorityClass",
-            "default": ""
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "description": "Security context settings for the Gotenberg pod",
-            "default": {}
-        },
-        "securityContext": {
-            "type": "object",
-            "description": "General security context settings for",
-            "default": {}
-        },
-        "autoscaling": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable or disable the HorizontalPodAutoscaler",
-                    "default": "false"
-                },
-                "minReplicas": {
-                    "type": "number",
-                    "description": "The minimum replicas to autoscale to",
-                    "default": "1"
-                },
-                "maxReplicas": {
-                    "type": "number",
-                    "description": "The maximum replicas to autoscale to",
-                    "default": "10"
-                },
-                "targetCPUUtilizationPercentage": {
-                    "type": "number",
-                    "description": "The CPU utilization at which to start autoscaling",
-                    "default": "80"
-                }
-            }
+        "pullSecrets": {
+          "type": "array",
+          "description": "A list of secrets to use for pulling images from private registries",
+          "default": [],
+          "items": {}
         }
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "String to partially override gotenberg.fullname",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "String to fully override gotenberg.fullname",
+      "default": ""
+    },
+    "gotenberg": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "type": "object",
+          "properties": {
+            "port": {
+              "type": "number",
+              "description": "The port the API should listen on",
+              "default": "3000"
+            },
+            "tlsCertFile": {
+              "type": "string",
+              "description": "Disable health check logging",
+              "default": "\"\""
+            },
+            "tlsKeyFile": {
+              "type": "string",
+              "description": "Disable health check logging",
+              "default": "\"\""
+            },
+            "startTimeout": {
+              "type": "string",
+              "description": "Set the time limit for the API to start",
+              "default": "30s"
+            },
+            "timeout": {
+              "type": "string",
+              "description": "Set the time limit for requests",
+              "default": "30s"
+            },
+            "rootPath": {
+              "type": "string",
+              "description": "Set the root path of the API",
+              "default": "\"/\""
+            },
+            "correlationIdHeader": {
+              "type": "string",
+              "description": "Set the header name to use for identifying requests",
+              "default": "\"\""
+            },
+            "disableHealthCheckLogging": {
+              "type": "boolean",
+              "description": "Disable health check route telemetry",
+              "default": "false"
+            },
+            "disableRootRouteTelemetry": {
+              "type": "boolean",
+              "description": "Disable telemetry for the root (\"/\") route",
+              "default": "false"
+            },
+            "disableDebugRouteTelemetry": {
+              "type": "boolean",
+              "description": "Disable telemetry for the /debug route",
+              "default": "false"
+            },
+            "disableVersionRouteTelemetry": {
+              "type": "boolean",
+              "description": "Disable telemetry for the /version route",
+              "default": "false"
+            },
+            "bodyLimit": {
+              "type": "string",
+              "description": "Set a cap on multipart/form-data request size, e.g. \"5MB\"",
+              "default": "\"\""
+            },
+            "bindIp": {
+              "type": "string",
+              "description": "Bind the API to a specific IP address",
+              "default": "0.0.0.0"
+            },
+            "enableDebugRoute": {
+              "type": "boolean",
+              "description": "Expose the /debug route with full instance configuration",
+              "default": "false"
+            },
+            "enableOidcAuth": {
+              "type": "boolean",
+              "description": "Enable OIDC bearer token authentication (mutually exclusive with basicAuth)",
+              "default": "false"
+            }
+          }
+        },
+        "basicAuth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable basic authentication",
+              "default": "false"
+            },
+            "username": {
+              "type": "string",
+              "description": "Set a username for HTTP Basic Auth",
+              "default": "\"\""
+            },
+            "password": {
+              "type": "string",
+              "description": "Set a password for HTTP Basic Auth",
+              "default": "\"\""
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "The name of an existing `basic-auth` secret",
+              "default": "\"\""
+            }
+          }
+        },
+        "chromium": {
+          "type": "object",
+          "properties": {
+            "restartAfter": {
+              "type": "number",
+              "description": "Number of conversions after which Chromium will auto-restart",
+              "default": "0"
+            },
+            "maxQueueSize": {
+              "type": "number",
+              "description": "Maximum request queue size for Chromium",
+              "default": "0"
+            },
+            "autoStart": {
+              "type": "boolean",
+              "description": "Automatically launch Chromium upon initialization if set to true",
+              "default": "false"
+            },
+            "startTimeout": {
+              "type": "string",
+              "description": "Maximum duration to wait for Chromium to start or restart",
+              "default": "20s"
+            },
+            "allowFileAccessFromFiles": {
+              "type": "boolean",
+              "description": "Allow file:// URIs to read other file:// URIs",
+              "default": "false"
+            },
+            "allowInsecureLocalhost": {
+              "type": "boolean",
+              "description": "Ignore TLS/SSL errors on localhost",
+              "default": "false"
+            },
+            "allowList": {
+              "type": "string",
+              "description": "Set the allowed URLs for Chromium using a regular expression - defaults to 'All'",
+              "default": "\"\""
+            },
+            "denyList": {
+              "type": "string",
+              "description": "Set the denied URLs for Chromium using a regular expression",
+              "default": "\"\""
+            },
+            "ignoreCertificateErrors": {
+              "type": "boolean",
+              "description": "Ignore the certificate errors",
+              "default": "false"
+            },
+            "disableWebSecurity": {
+              "type": "boolean",
+              "description": "Don't enforce the same-origin policy",
+              "default": "false"
+            },
+            "hostResolverRules": {
+              "type": "string",
+              "description": "Set custom mappings to the host resolver",
+              "default": "\"\""
+            },
+            "proxyServer": {
+              "type": "string",
+              "description": "Set the outbound proxy server; this switch only affects HTTP and HTTPS requests",
+              "default": "\"\""
+            },
+            "clearCache": {
+              "type": "boolean",
+              "description": "Clear Chromium cache between each conversion",
+              "default": "false"
+            },
+            "clearCookies": {
+              "type": "boolean",
+              "description": "Clear Chromium cookies between each conversion",
+              "default": "false"
+            },
+            "disableJavaScript": {
+              "type": "boolean",
+              "description": "Disable JavaScript",
+              "default": "false"
+            },
+            "disableRoutes": {
+              "type": "boolean",
+              "description": "Disable the routes",
+              "default": "false"
+            },
+            "maxConcurrency": {
+              "type": "number",
+              "description": "Maximum number of simultaneous Chromium conversions",
+              "default": "6"
+            },
+            "idleShutdownTimeout": {
+              "type": "string",
+              "description": "Auto-stop Chromium after this idle period; set to \"0s\" to disable",
+              "default": "\"0s\""
+            },
+            "clearStorage": {
+              "type": "boolean",
+              "description": "Clear browser storage between each conversion",
+              "default": "false"
+            },
+            "denyPrivateIps": {
+              "type": "boolean",
+              "description": "Reject Chromium navigations/sub-resources resolving to a non-public IP",
+              "default": "false"
+            },
+            "denyPublicIps": {
+              "type": "boolean",
+              "description": "Reject Chromium navigations/sub-resources resolving to a public IP",
+              "default": "false"
+            },
+            "enableEnvironmentProxy": {
+              "type": "boolean",
+              "description": "Route outbound Chromium traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
+              "default": "false"
+            }
+          }
+        },
+        "libreOffice": {
+          "type": "object",
+          "properties": {
+            "restartAfter": {
+              "type": "number",
+              "description": "Number of conversions after which LibreOffice will automatically restart",
+              "default": "10"
+            },
+            "maxQueueSize": {
+              "type": "number",
+              "description": "Maximum request queue size for LibreOffice",
+              "default": "0"
+            },
+            "autoStart": {
+              "type": "boolean",
+              "description": "Automatically launch LibreOffice upon initialization if set to true",
+              "default": "false"
+            },
+            "startTimeout": {
+              "type": "string",
+              "description": "Maximum duration to wait for LibreOffice to start or restart",
+              "default": "20s"
+            },
+            "disableRoutes": {
+              "type": "boolean",
+              "description": "Disable the route",
+              "default": "false"
+            },
+            "idleShutdownTimeout": {
+              "type": "string",
+              "description": "Auto-stop LibreOffice after this idle period; set to \"0s\" to disable",
+              "default": "\"0s\""
+            },
+            "allowList": {
+              "type": "string",
+              "description": "Set the allowed URLs for LibreOffice's outbound fetches using a regular expression",
+              "default": "\"\""
+            },
+            "denyList": {
+              "type": "string",
+              "description": "Set the denied URLs for LibreOffice's outbound fetches using a regular expression",
+              "default": "\"\""
+            },
+            "denyPrivateIps": {
+              "type": "boolean",
+              "description": "Reject LibreOffice outbound fetches resolving to a non-public IP",
+              "default": "false"
+            },
+            "denyPublicIps": {
+              "type": "boolean",
+              "description": "Reject LibreOffice outbound fetches resolving to a public IP",
+              "default": "false"
+            },
+            "enableEnvironmentProxy": {
+              "type": "boolean",
+              "description": "Route outbound LibreOffice traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
+              "default": "false"
+            }
+          }
+        },
+        "pdf": {
+          "type": "object",
+          "properties": {
+            "convertEngines": {
+              "type": "string",
+              "description": "Set the PDF conversion engines and their order",
+              "default": "libreoffice-pdfengine"
+            },
+            "readMetadataEngines": {
+              "type": "string",
+              "description": "Set the PDF metadata-reading engines and their order",
+              "default": "exiftool"
+            },
+            "writeMetadataEngines": {
+              "type": "string",
+              "description": "Set the PDF metadata-writing engines and their order",
+              "default": "exiftool"
+            },
+            "disableRoutes": {
+              "type": "boolean",
+              "description": "Disable the routes",
+              "default": "false"
+            }
+          }
+        },
+        "webhook": {
+          "type": "object",
+          "properties": {
+            "allowList": {
+              "type": "string",
+              "description": "Set the allowed URLs for the webhook feature using a regular expression",
+              "default": "\"\""
+            },
+            "denyList": {
+              "type": "string",
+              "description": "Set the denied URLs for the webhook feature using a regular expression",
+              "default": "\"\""
+            },
+            "errorAllowList": {
+              "type": "string",
+              "description": "Set the allowed URLs in case of an error using a regular expression",
+              "default": "\"\""
+            },
+            "errorDenyList": {
+              "type": "string",
+              "description": "Set the denied URLs in case of an error using a regular expression",
+              "default": "\"\""
+            },
+            "maxRetry": {
+              "type": "number",
+              "description": "Set the maximum number of retries",
+              "default": "4"
+            },
+            "retryMinWait": {
+              "type": "string",
+              "description": "Set the minimum duration to wait before trying to call the webhook again",
+              "default": "1s"
+            },
+            "retryMaxWait": {
+              "type": "string",
+              "description": "Set the maximum duration to wait before trying to call the webhook again",
+              "default": "30s"
+            },
+            "clientTimeout": {
+              "type": "string",
+              "description": "Set the time limit for requests to the webhook",
+              "default": "30s"
+            },
+            "disable": {
+              "type": "boolean",
+              "description": "Disable the webhook feature",
+              "default": "false"
+            },
+            "denyPrivateIps": {
+              "type": "boolean",
+              "description": "Reject webhook URLs (success, error, events) resolving to a non-public IP",
+              "default": "false"
+            },
+            "denyPublicIps": {
+              "type": "boolean",
+              "description": "Reject webhook URLs resolving to a public IP",
+              "default": "false"
+            },
+            "enableEnvironmentProxy": {
+              "type": "boolean",
+              "description": "Route outbound webhook traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY",
+              "default": "false"
+            }
+          }
+        },
+        "prometheus": {
+          "type": "object",
+          "properties": {
+            "collectInterval": {
+              "type": "string",
+              "description": "Set the interval for collecting modules' metrics",
+              "default": "1s"
+            },
+            "namespace": {
+              "type": "string",
+              "description": "Set the namespace of modules' metrics",
+              "default": "gotenberg"
+            },
+            "disableCollect": {
+              "type": "boolean",
+              "description": "Disable the collect of metrics",
+              "default": "false"
+            },
+            "disableRouteTelemetry": {
+              "type": "boolean",
+              "description": "Disable telemetry for the /prometheus route",
+              "default": "false"
+            },
+            "metricsPath": {
+              "type": "string",
+              "description": "Customise the Prometheus scrape endpoint path",
+              "default": "\"\""
+            }
+          }
+        },
+        "openTelemetry": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable OpenTelemetry tracing/metrics/logging env vars below",
+              "default": "false"
+            },
+            "tracesExporter": {
+              "type": "string",
+              "description": "Sets OTEL_TRACES_EXPORTER",
+              "default": "\"\""
+            },
+            "metricsExporter": {
+              "type": "string",
+              "description": "Sets OTEL_METRICS_EXPORTER",
+              "default": "\"\""
+            },
+            "logsExporter": {
+              "type": "string",
+              "description": "Sets OTEL_LOGS_EXPORTER",
+              "default": "\"\""
+            },
+            "exporterOtlpEndpoint": {
+              "type": "string",
+              "description": "Sets OTEL_EXPORTER_OTLP_ENDPOINT",
+              "default": "\"\""
+            }
+          }
+        },
+        "logging": {
+          "type": "object",
+          "properties": {
+            "format": {
+              "type": "string",
+              "description": "Specify the format of logging",
+              "default": "auto"
+            },
+            "level": {
+              "type": "string",
+              "description": "Choose the level of logging detail",
+              "default": "info"
+            },
+            "levelCase": {
+              "type": "string",
+              "description": "Set the level field casing in standard output",
+              "default": "lower"
+            },
+            "fieldsPrefix": {
+              "type": "string",
+              "description": "Prepend a specified prefix to each field in the logs",
+              "default": "\"\""
+            },
+            "enableGcpFields": {
+              "type": "boolean",
+              "description": "Use GCP Cloud Run-compatible structured log field names",
+              "default": "false"
+            }
+          }
+        },
+        "shutdown": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "type": "string",
+              "description": "Set the graceful shutdown duration",
+              "default": "30s"
+            }
+          }
+        }
+      }
+    },
+    "secret": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "Common annotations for the SMTP, HIBP, Admin and Database secrets",
+          "default": {}
+        },
+        "labels": {
+          "type": "object",
+          "description": "Common extra labels for the SMTP, HIBP, Admin and Database secrets",
+          "default": {}
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Ingress",
+          "default": false
+        },
+        "className": {
+          "type": "string",
+          "description": "The IngressClass to use for the pod's ingress",
+          "default": ""
+        },
+        "whitelist": {
+          "type": "string",
+          "description": "A comma-separated list of IP addresses to whitelist",
+          "default": ""
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the Ingress resource",
+          "default": {}
+        },
+        "tls": {
+          "type": "array",
+          "description": "A list of hostnames and secret names to use for TLS",
+          "default": [],
+          "items": {}
+        },
+        "hosts": {
+          "type": "array",
+          "description": "A list of hosts for the Ingress resource",
+          "default": [],
+          "items": {}
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of service to create",
+          "default": "ClusterIP"
+        },
+        "port": {
+          "type": "number",
+          "description": "The port to use on the service",
+          "default": "80"
+        },
+        "nodePort": {
+          "type": "number",
+          "description": "The Node port to use on the service",
+          "default": "30080"
+        },
+        "extraPorts": {
+          "type": "array",
+          "description": "Extra ports to add to the service",
+          "default": [],
+          "items": {}
+        },
+        "externalTrafficPolicy": {
+          "type": "string",
+          "description": "The external traffic policy for the service",
+          "default": "Cluster"
+        },
+        "internalTrafficPolicy": {
+          "type": "string",
+          "description": "The internal traffic policy for the service",
+          "default": "Cluster"
+        },
+        "clusterIP": {
+          "type": "string",
+          "description": "Define a static cluster IP for the service",
+          "default": "\"\""
+        },
+        "loadBalancerIP": {
+          "type": "string",
+          "description": "Set the Load Balancer IP",
+          "default": ""
+        },
+        "loadBalancerClass": {
+          "type": "string",
+          "description": "Define Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)",
+          "default": ""
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "description": "Service Load Balancer source ranges",
+          "default": [],
+          "items": {}
+        },
+        "externalIPs": {
+          "type": "array",
+          "description": "Service External IPs",
+          "default": [],
+          "items": {}
+        },
+        "sessionAffinity": {
+          "type": "string",
+          "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+          "default": "None"
+        },
+        "sessionAffinityConfig": {
+          "type": "object",
+          "description": "Additional settings for the sessionAffinity",
+          "default": {}
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create RBAC resources",
+          "default": true
+        },
+        "rules": {
+          "type": "array",
+          "description": "Extra rules to add to the Role",
+          "default": [],
+          "items": {}
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether a service account should be created",
+          "default": true
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Whether to automount the service account token",
+          "default": false
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account",
+          "default": {}
+        },
+        "name": {
+          "type": "string",
+          "description": "A custom name for the service account, otherwise gotenberg.fullname is used",
+          "default": ""
+        },
+        "secrets": {
+          "type": "array",
+          "description": "A list of secrets mountable by this service account",
+          "default": [],
+          "items": {}
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the use of liveness probes",
+          "default": false
+        },
+        "initialDelaySeconds": {
+          "type": "number",
+          "description": "Configure the initial delay seconds for the liveness probe",
+          "default": 5
+        },
+        "timeoutSeconds": {
+          "type": "number",
+          "description": "Configure the initial delay seconds for the liveness probe",
+          "default": 1
+        },
+        "periodSeconds": {
+          "type": "number",
+          "description": "Configure the seconds for each period of the liveness probe",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "number",
+          "description": "Configure the success threshold for the liveness probe",
+          "default": 1
+        },
+        "failureThreshold": {
+          "type": "number",
+          "description": "Configure the failure threshold for the liveness probe",
+          "default": 10
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the use of readiness probes",
+          "default": false
+        },
+        "initialDelaySeconds": {
+          "type": "number",
+          "description": "Configure the initial delay seconds for the readiness probe",
+          "default": 5
+        },
+        "timeoutSeconds": {
+          "type": "number",
+          "description": "Configure the initial delay seconds for the readiness probe",
+          "default": 1
+        },
+        "periodSeconds": {
+          "type": "number",
+          "description": "Configure the seconds for each period of the readiness probe",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "number",
+          "description": "Configure the success threshold for the readiness probe",
+          "default": 1
+        },
+        "failureThreshold": {
+          "type": "number",
+          "description": "Configure the failure threshold for the readiness probe",
+          "default": 3
+        }
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the use of readiness probes",
+          "default": false
+        },
+        "initialDelaySeconds": {
+          "type": "number",
+          "description": "Configure the initial delay seconds for the startup probe",
+          "default": 5
+        },
+        "timeoutSeconds": {
+          "type": "number",
+          "description": "Configure the initial delay seconds for the startup probe",
+          "default": 1
+        },
+        "periodSeconds": {
+          "type": "number",
+          "description": "Configure the seconds for each period of the startup probe",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "number",
+          "description": "Configure the success threshold for the startup probe",
+          "default": 1
+        },
+        "failureThreshold": {
+          "type": "number",
+          "description": "Configure the failure threshold for the startup probe",
+          "default": 10
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the pod disruption budget",
+          "default": "true"
+        },
+        "minAvailable": {
+          "type": "number",
+          "description": "The minimum amount of pods which need to be available",
+          "default": "1"
+        }
+      }
+    },
+    "replicas": {
+      "type": "number",
+      "description": "The amount of replicas Gotenberg deployment should create",
+      "default": 1
+    },
+    "resources": {
+      "type": "object",
+      "description": "The resource limits/requests for the Gotenberg pod",
+      "default": {}
+    },
+    "extraEnvVars": {
+      "type": "array",
+      "description": "Extra environment variables for the Gotenberg pod, e.g. for TZ",
+      "default": [],
+      "items": {}
+    },
+    "volumes": {
+      "type": "array",
+      "description": "Define volumes for the Gotenberg pod",
+      "default": [],
+      "items": {}
+    },
+    "volumeMounts": {
+      "type": "array",
+      "description": "Define volumeMounts for the Gotenberg pod",
+      "default": [],
+      "items": {}
+    },
+    "initContainers": {
+      "type": "array",
+      "description": "Define initContainers for the main Gotenberg server",
+      "default": [],
+      "items": {}
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node labels for pod assignment",
+      "default": {}
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod assignment",
+      "default": [],
+      "items": {}
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity for pod assignment",
+      "default": {}
+    },
+    "strategy": {
+      "type": "object",
+      "description": "Specify a deployment strategy for the Gotenberg pod",
+      "default": {}
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Extra annotations for the Gotenberg pod",
+      "default": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Extra labels for the Gotenberg pod",
+      "default": {}
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "The name of an existing PriorityClass",
+      "default": ""
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context settings for the Gotenberg pod",
+      "default": {}
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "General security context settings for",
+      "default": {}
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the HorizontalPodAutoscaler",
+          "default": "false"
+        },
+        "minReplicas": {
+          "type": "number",
+          "description": "The minimum replicas to autoscale to",
+          "default": "1"
+        },
+        "maxReplicas": {
+          "type": "number",
+          "description": "The maximum replicas to autoscale to",
+          "default": "10"
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "number",
+          "description": "The CPU utilization at which to start autoscaling",
+          "default": "80"
+        }
+      }
     }
+  }
 }

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/gotenberg.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: gotenberg/gotenberg
-  tag: 8.7.0
+  tag: 8.36.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -74,12 +74,36 @@ gotenberg:
     ## @param gotenberg.api.rootPath [default: "/"] Set the root path of the API
     ##
     rootPath: /
-    ## @param gotenberg.api.traceHeader [string] Set the header name to use for identifying requests
+    ## @param gotenberg.api.correlationIdHeader [string] Set the header name to use for identifying requests
+    ## Renamed from `traceHeader` in Gotenberg 8.29 (`--api-trace-header` -> `--api-correlation-id-header`)
     ##
-    traceHeader: ""
-    ## @param gotenberg.api.disableHealthCheckLogging [default: false] Disable health check logging
+    correlationIdHeader: ""
+    ## @param gotenberg.api.disableHealthCheckLogging [default: false] Disable health check route telemetry
+    ## Renamed from `--api-disable-health-check-logging` in Gotenberg 8.29
     ##
     disableHealthCheckLogging: false
+    ## @param gotenberg.api.disableRootRouteTelemetry [default: false] Disable telemetry for the root ("/") route
+    ##
+    disableRootRouteTelemetry: false
+    ## @param gotenberg.api.disableDebugRouteTelemetry [default: false] Disable telemetry for the /debug route
+    ##
+    disableDebugRouteTelemetry: false
+    ## @param gotenberg.api.disableVersionRouteTelemetry [default: false] Disable telemetry for the /version route
+    ##
+    disableVersionRouteTelemetry: false
+    ## @param gotenberg.api.bodyLimit [string] Set a cap on multipart/form-data request size, e.g. "5MB"
+    ##
+    bodyLimit: ""
+    ## @param gotenberg.api.bindIp [default: 0.0.0.0] Bind the API to a specific IP address
+    ##
+    bindIp: ""
+    ## @param gotenberg.api.enableDebugRoute [default: false] Expose the /debug route with full instance configuration
+    ##
+    enableDebugRoute: false
+    ## @param gotenberg.api.enableOidcAuth [default: false] Enable OIDC bearer token authentication (mutually exclusive with basicAuth)
+    ## See https://gotenberg.dev/docs/configuration for the full OIDC issuer/audience configuration required alongside this flag
+    ##
+    enableOidcAuth: false
 
   ## BasicAuth configuration
   ##
@@ -133,9 +157,6 @@ gotenberg:
     ## @param gotenberg.chromium.disableWebSecurity [default: false] Don't enforce the same-origin policy
     ##
     disableWebSecurity: false
-    ## @param gotenberg.chromium.incognito [default: false] Start Chromium with incognito mode
-    ##
-    incognito: false
     ## @param gotenberg.chromium.hostResolverRules [string] Set custom mappings to the host resolver
     ##
     hostResolverRules: ""
@@ -154,6 +175,25 @@ gotenberg:
     ## @param gotenberg.chromium.disableRoutes [default: false] Disable the routes
     ##
     disableRoutes: false
+    ## @param gotenberg.chromium.maxConcurrency [default: 6] Maximum number of simultaneous Chromium conversions
+    ##
+    maxConcurrency: 6
+    ## @param gotenberg.chromium.idleShutdownTimeout [default: "0s"] Auto-stop Chromium after this idle period; set to "0s" to disable
+    ##
+    idleShutdownTimeout: "0s"
+    ## @param gotenberg.chromium.clearStorage [default: false] Clear browser storage between each conversion
+    ##
+    clearStorage: false
+    ## @param gotenberg.chromium.denyPrivateIps [default: false] Reject Chromium navigations/sub-resources resolving to a non-public IP
+    ##
+    denyPrivateIps: false
+    ## @param gotenberg.chromium.denyPublicIps [default: false] Reject Chromium navigations/sub-resources resolving to a public IP
+    ##
+    denyPublicIps: false
+    ## @param gotenberg.chromium.enableEnvironmentProxy [default: false] Route outbound Chromium traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+    ## Since Gotenberg 8.35, the outbound client no longer inherits these env vars implicitly - this must be opted into explicitly
+    ##
+    enableEnvironmentProxy: false
 
   ## LibreOffice configuration
   ##
@@ -176,13 +216,38 @@ gotenberg:
     ## @param gotenberg.libreOffice.disableRoutes [default: false] Disable the route
     ##
     disableRoutes: false
+    ## @param gotenberg.libreOffice.idleShutdownTimeout [default: "0s"] Auto-stop LibreOffice after this idle period; set to "0s" to disable
+    ##
+    idleShutdownTimeout: "0s"
+    ## @param gotenberg.libreOffice.allowList [string] Set the allowed URLs for LibreOffice's outbound fetches using a regular expression
+    ##
+    allowList: ""
+    ## @param gotenberg.libreOffice.denyList [string] Set the denied URLs for LibreOffice's outbound fetches using a regular expression
+    ##
+    denyList: ""
+    ## @param gotenberg.libreOffice.denyPrivateIps [default: false] Reject LibreOffice outbound fetches resolving to a non-public IP
+    ##
+    denyPrivateIps: false
+    ## @param gotenberg.libreOffice.denyPublicIps [default: false] Reject LibreOffice outbound fetches resolving to a public IP
+    ##
+    denyPublicIps: false
+    ## @param gotenberg.libreOffice.enableEnvironmentProxy [default: false] Route outbound LibreOffice traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+    ##
+    enableEnvironmentProxy: false
 
   ## PDF Engines configuration
   ##
   pdf:
-    ## @param gotenberg.pdf.engines [string] Set the PDF engines and their order - defaults to 'All'
+    ## @param gotenberg.pdf.convertEngines [default: libreoffice-pdfengine] Set the PDF conversion engines and their order
+    ## Replaces the single `engines` key removed in Gotenberg 8.13 (`--pdfengines-engines` -> `--pdfengines-convert-engines`)
     ##
-    engines: ""
+    convertEngines: ""
+    ## @param gotenberg.pdf.readMetadataEngines [default: exiftool] Set the PDF metadata-reading engines and their order
+    ##
+    readMetadataEngines: ""
+    ## @param gotenberg.pdf.writeMetadataEngines [default: exiftool] Set the PDF metadata-writing engines and their order
+    ##
+    writeMetadataEngines: ""
     ## @param gotenberg.pdf.disableRoutes [default: false] Disable the routes
     ##
     disableRoutes: false
@@ -221,8 +286,18 @@ gotenberg:
     ## @param gotenberg.webhook.disable [default: false] Disable the webhook feature
     ##
     disable: false
+    ## @param gotenberg.webhook.denyPrivateIps [default: false] Reject webhook URLs (success, error, events) resolving to a non-public IP
+    ##
+    denyPrivateIps: false
+    ## @param gotenberg.webhook.denyPublicIps [default: false] Reject webhook URLs resolving to a public IP
+    ##
+    denyPublicIps: false
+    ## @param gotenberg.webhook.enableEnvironmentProxy [default: false] Route outbound webhook traffic through HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+    ##
+    enableEnvironmentProxy: false
 
   ## Prometheus configuration
+  ## Note: as of Gotenberg 8.29, Prometheus is complemented by full OpenTelemetry support - see gotenberg.openTelemetry below
   ##
   prometheus:
     ## @param gotenberg.prometheus.collectInterval [default: 1s] Set the interval for collecting modules' metrics
@@ -234,24 +309,58 @@ gotenberg:
     ## @param gotenberg.prometheus.disableCollect [default: false] Disable the collect of metrics
     ##
     disableCollect: false
-    ## @param gotenberg.prometheus.disableRouteLogging [default: false] Disable the route logging
+    ## @param gotenberg.prometheus.disableRouteTelemetry [default: false] Disable telemetry for the /prometheus route
+    ## Renamed from `disableRouteLogging` in Gotenberg 8.29 (`--prometheus-disable-route-logging` -> `--prometheus-disable-route-telemetry`)
     ##
-    disableRouteLogging: false
+    disableRouteTelemetry: false
+    ## @param gotenberg.prometheus.metricsPath [string] Customise the Prometheus scrape endpoint path
+    ##
+    metricsPath: ""
+
+  ## OpenTelemetry configuration (Gotenberg 8.29+)
+  ## Gotenberg reads standard OTEL_* environment variables - ref: https://gotenberg.dev/docs/configuration
+  ##
+  openTelemetry:
+    ## @param gotenberg.openTelemetry.enabled [default: false] Enable OpenTelemetry tracing/metrics/logging env vars below
+    ##
+    enabled: false
+    ## @param gotenberg.openTelemetry.tracesExporter [string] Sets OTEL_TRACES_EXPORTER
+    ##
+    tracesExporter: ""
+    ## @param gotenberg.openTelemetry.metricsExporter [string] Sets OTEL_METRICS_EXPORTER
+    ##
+    metricsExporter: ""
+    ## @param gotenberg.openTelemetry.logsExporter [string] Sets OTEL_LOGS_EXPORTER
+    ##
+    logsExporter: ""
+    ## @param gotenberg.openTelemetry.exporterOtlpEndpoint [string] Sets OTEL_EXPORTER_OTLP_ENDPOINT
+    ##
+    exporterOtlpEndpoint: ""
+    ## @param gotenberg.openTelemetry.extraEnv [object] Extra OTEL_* environment variables not covered above
+    ##
+    extraEnv: {}
 
   ## Logging configuration
   ##
   logging:
     ## @param gotenberg.logging.format [default: auto] Specify the format of logging
-    ## Options include auto, json, or text
+    ## Options include auto, json, or text. Renamed from `--log-format` to `--log-std-format` in Gotenberg 8.29
     ##
     format: auto
     ## @param gotenberg.logging.level [default: info] Choose the level of logging detail
     ## Options include error, warn, info, or debug
     ##
     level: info
+    ## @param gotenberg.logging.levelCase [default: lower] Set the level field casing in standard output
+    ## Options include lower or upper
+    ##
+    levelCase: lower
     ## @param gotenberg.logging.fieldsPrefix [string] Prepend a specified prefix to each field in the logs
     ##
     fieldsPrefix: ""
+    ## @param gotenberg.logging.enableGcpFields [default: false] Use GCP Cloud Run-compatible structured log field names
+    ##
+    enableGcpFields: false
 
   ## Shutdown configuration
   ##
@@ -521,6 +630,13 @@ resources: {}
 # requests:
 #   cpu: 100m
 #   memory: 128Mi
+
+## @param extraEnvVars Extra environment variables for the Gotenberg pod, e.g. for TZ
+## extraEnvVars:
+##   - name: TZ
+##     value: "Europe/Berlin"
+##
+extraEnvVars: []
 
 ## ref: https://kubernetes.io/docs/concepts/storage/volumes/
 ## @param volumes Define volumes for the Gotenberg pod

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -20,7 +20,7 @@ keywords:
   - federation
   - keycloak
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -38,9 +38,9 @@ annotations:
       image: quay.io/keycloak/keycloak-operator:26.0.6
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Keycloak GitHub Repository
       url: https://github.com/keycloak/keycloak
     - name: Keycloak Documentation

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 26.0.6
 kubeVersion: ">=1.26.0-0"
 name: keycloak-operator
-version: 0.2.1
+version: 0.2.2
 description: Keycloak is an open source software product to allow single sign-on with identity and access management
 home: https://github.com/keycloak/keycloak
 icon: https://raw.githubusercontent.com/keycloak/keycloak-misc/main/logo/logo.png

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -21,14 +21,14 @@ on [quay.io](https://quay.io/repository/keycloak/keycloak-operator).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install vaultwarden adnoctem/keycloak-operator --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/keycloak-operator:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/keycloak-operator:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/keycloak-operator.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/kubenav/Chart.yaml
+++ b/charts/kubenav/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - kubeconfig
   - rbac
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -31,9 +31,9 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Kubenav Homepage
       url: https://kubenav.io/
   org.opencontainers.image.vendor: "Ad Noctem Collective"

--- a/charts/kubenav/Chart.yaml
+++ b/charts/kubenav/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 kubeVersion: ">=1.26.0-0"
 name: kubenav
-version: 0.2.1
+version: 0.2.2
 description: "kubenav is the navigator for your Kubernetes clusters in your pocket: a mobile app to manage clusters and get an overview of the status of your resources"
 home: https://kubenav.io/
 icon: https://raw.githubusercontent.com/kubenav/kubenav/290f1776b03c359b8115125fa37a4b8dd73b6464/utils/images/app-icons/android.png

--- a/charts/kubenav/README.md
+++ b/charts/kubenav/README.md
@@ -16,14 +16,14 @@ through our [contribution guidelines](https://github.com/kubenav/kubenav/blob/ma
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install kubenav adnoctem/kubenav --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/kubenav:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/kubenav:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/kubenav/values.yaml
+++ b/charts/kubenav/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/kubenav.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/linkstack/Chart.yaml
+++ b/charts/linkstack/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
   - linktree
   - linkstack
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -36,9 +36,9 @@ annotations:
       image: docker.io/linkstackorg/linkstack:latest@sha256:abd691b4293b020a317de8794737671e0315159efcb868e8a4124d6f0611f7ae
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Linkstack GitHub Repository
       url: https://github.com/LinkStackOrg/LinkStack
     - name: Linkstack Documentation

--- a/charts/linkstack/Chart.yaml
+++ b/charts/linkstack/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 4.8.0
 kubeVersion: ">=1.26.0-0"
 name: linkstack
-version: 0.3.1
+version: 0.3.2
 description: LinkStack is a highly customizable link sharing platform with an intuitive, easy to use user interface
 home: https://github.com/LinkStackOrg/LinkStack
 icon: https://raw.githubusercontent.com/LinkStackOrg/branding/c22886d7585246836d5e4e597484b92b51c76f0c/logo/png/logo.png

--- a/charts/linkstack/README.md
+++ b/charts/linkstack/README.md
@@ -16,14 +16,14 @@ single Docker image available on [Docker Hub](https://hub.docker.com/r/linkstack
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install linkstack adnoctem/linkstack --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/linkstack:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/linkstack:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/linkstack/ci/test-values.yaml
+++ b/charts/linkstack/ci/test-values.yaml
@@ -1,6 +1,6 @@
 linkstack:
   serverAdmin: info@adnoctem.co
-  serverName: linkstack.helm.internal
+  serverName: linkstack.charts.internal
   logLevel: warn
   timeZone: Europe/Berlin
   phpMemoryLimit: 512M
@@ -16,7 +16,7 @@ ingress:
   tls:
     - secretName: linkstack-ingress-tls
       hosts:
-        - linkstack.helm.internal
+        - linkstack.charts.internal
 
 livenessProbe:
   enabled: true

--- a/charts/linkstack/values.yaml
+++ b/charts/linkstack/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/linkstack.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.5.3
 kubeVersion: ">=1.26.0-0"
 name: linkwarden
-version: 0.4.1
+version: 0.4.2
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
   - linkace
   - archivebox
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -40,9 +40,9 @@ annotations:
       image: ghcr.io/linkwarden/linkwarden:v2.5.3
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Linkwarden Homepage
       url: https://linkwarden.app/
     - name: Linkwarden Documentation

--- a/charts/linkwarden/README.md
+++ b/charts/linkwarden/README.md
@@ -30,14 +30,14 @@ the [GitHub Container Registry](https://github.com/linkwarden/linkwarden/pkgs/co
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install linkwarden adnoctem/linkwarden --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/linkwarden:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/linkwarden:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/linkwarden/ci/test-values.yaml
+++ b/charts/linkwarden/ci/test-values.yaml
@@ -1,5 +1,5 @@
 linkwarden:
-  domain: "linkwarden.helm.internal"
+  domain: "linkwarden.charts.internal"
   nextAuthSecret:
     value: "PretendThisIsARandomString"
   ignoreUnauthorizedCA: true
@@ -33,7 +33,7 @@ ingress:
   tls:
     - secretName: linkwarden-ingress-tls
       hosts:
-        - "linkwarden.helm.internal"
+        - "linkwarden.charts.internal"
 
 livenessProbe:
   enabled: true

--- a/charts/linkwarden/values.yaml
+++ b/charts/linkwarden/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/linkwarden.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - mobile
   - ntfy
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -35,9 +35,9 @@ annotations:
       image: docker.io/binwiederhier/ntfy:v2.11.0
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: ntfy GitHub Repository
       url: https://github.com/binwiederhier/ntfy
     - name: ntfy Documentation

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.11.0
 kubeVersion: ">=1.26.0-0"
 name: ntfy
-version: 0.3.1
+version: 0.3.2
 description: ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests
 home: https://github.com/binwiederhier/ntfy
 icon: https://raw.githubusercontent.com/binwiederhier/ntfy/9d3fc20e583564e40af5afb90233f4714fdfcb4c/web/public/static/images/pwa-512x512.png

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -15,14 +15,14 @@ on [Docker Hub](https://hub.docker.com/r/binwiederhier/ntfy).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install ntfy adnoctem/ntfy --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/ntfy:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/ntfy:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -168,14 +168,14 @@ Parameters.
 
 ### Ingress parameters
 
-| Name                  | Description                                                        | Value   |
-| --------------------- | ------------------------------------------------------------------ | ------- |
-| `ingress.enabled`     | Whether to enable Ingress                                          | `false` |
-| `ingress.className`   | The IngressClass to use for the pod's ingress                      | `""`    |
-| `ingress.whitelist`   | A comma-separated list of IP addresses to whitelist                | `""`    |
-| `ingress.annotations` | Annotations for the Ingress resource                               | `{}`    |
-| `ingress.tls`         | A list of hostnames and secret names to use for TLS                | `[]`    |
-| `ingress.extraHosts`  | A list of extra hosts for the Ingress resource (with ntfy.baseURL) | `[]`    |
+| Name                  | Description                                         | Value   |
+| --------------------- | --------------------------------------------------- | ------- |
+| `ingress.enabled`     | Whether to enable Ingress                           | `false` |
+| `ingress.className`   | The IngressClass to use for the pod's ingress       | `""`    |
+| `ingress.whitelist`   | A comma-separated list of IP addresses to whitelist | `""`    |
+| `ingress.annotations` | Annotations for the Ingress resource                | `{}`    |
+| `ingress.tls`         | A list of hostnames and secret names to use for TLS | `[]`    |
+| `ingress.hosts`       | A list of hosts for the Ingress resource            | `[]`    |
 
 ### Service parameters
 

--- a/charts/ntfy/ci/test-values.yaml
+++ b/charts/ntfy/ci/test-values.yaml
@@ -1,5 +1,5 @@
 ntfy:
-  baseURL: ntfy.helm.internal
+  baseURL: ntfy.charts.internal
   listenHTTP: ":8080"
   listenHTTPS: ""
   keyFile: ""
@@ -47,7 +47,7 @@ ingress:
   tls:
     - secretName: ntfy-ingress-tls
       hosts:
-        - ntfy.helm.internal
+        - ntfy.charts.internal
 
 service:
   type: ClusterIP

--- a/charts/ntfy/ci/test-values.yaml
+++ b/charts/ntfy/ci/test-values.yaml
@@ -1,5 +1,5 @@
 ntfy:
-  baseURL: ntfy.charts.internal
+  baseURL: https://ntfy.charts.internal
   listenHTTP: ":8080"
   listenHTTPS: ""
   keyFile: ""

--- a/charts/ntfy/ci/test-values.yaml
+++ b/charts/ntfy/ci/test-values.yaml
@@ -44,6 +44,11 @@ ingress:
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: development-issuer
+  hosts:
+    - host: ntfy.charts.internal
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls:
     - secretName: ntfy-ingress-tls
       hosts:

--- a/charts/ntfy/templates/NOTES.txt
+++ b/charts/ntfy/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.extraHosts }}
+{{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}

--- a/charts/ntfy/templates/_podSpec.yaml
+++ b/charts/ntfy/templates/_podSpec.yaml
@@ -40,6 +40,10 @@ template:
       - name: {{ .Chart.Name }}
         image: {{ include "ntfy.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - serve
+          - --config
+          - /etc/ntfy/config.yml
         env:
             {{- if (or .Values.ntfy.smtp.senderUser .Values.ntfy.smtp.existingSecret) }}
           - name: NTFY_SMTP_SENDER_USER
@@ -102,7 +106,7 @@ template:
             {{- end }}
         volumeMounts:
           - name: {{ printf "%s-config" (include "ntfy.fullname" .) }}
-            mountPath: /var/lib/ntfy
+            mountPath: /etc/ntfy
             {{- if (or .Values.ntfy.cache.file .Values.ntfy.auth.file .Values.ntfy.attachment.cacheDir) }}
           - name: {{ include "ntfy.pv" . }}
             mountPath: {{ .Values.ntfy.data.rootPath }}

--- a/charts/ntfy/templates/ingress.yaml
+++ b/charts/ntfy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ntfy.fullname" . -}}
-{{- $svcPort := .Values.service.ports.https -}}
+{{- $svcPort := .Values.service.ports.http -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -38,24 +38,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ntfy.baseURL | quote }}
-      http:
-        paths:
-          - path: /
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: Prefix
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-    {{- range .Values.ingress.extraHosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/ntfy/values.schema.json
+++ b/charts/ntfy/values.schema.json
@@ -590,9 +590,9 @@
           "default": [],
           "items": {}
         },
-        "extraHosts": {
+        "hosts": {
           "type": "array",
-          "description": "A list of extra hosts for the Ingress resource (with ntfy.baseURL)",
+          "description": "A list of hosts for the Ingress resource",
           "default": [],
           "items": {}
         }

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/ntfy.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -435,7 +435,7 @@ secret:
 ## @param ingress.whitelist A comma-separated list of IP addresses to whitelist
 ## @param ingress.annotations Annotations for the Ingress resource
 ## @param ingress.tls A list of hostnames and secret names to use for TLS
-## @param ingress.extraHosts A list of extra hosts for the Ingress resource (with ntfy.baseURL)
+## @param ingress.hosts A list of hosts for the Ingress resource
 
 ingress:
   enabled: false
@@ -448,7 +448,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  extraHosts: []
+  hosts: []
   # - host: domain.tld
   #   paths:
   #     - path: /

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -20,7 +20,8 @@ dependencies:
     condition: tika.enabled
     version: ~2.9
   - name: gotenberg
-    repository: oci://ghcr.io/adnoctem/charts
+    # TODO: switch to oci://ghcr.io/adnoctem/charts once gotenberg is published there (nothing pushed yet post-rename)
+    repository: oci://ghcr.io/adnoctem/helm
     condition: gotenberg.enabled
     version: ~0.3.0
 description: Paperless-NGX is a community-supported supercharged version of paperless - scan, index and archive all your physical documents

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.10.1
 kubeVersion: ">=1.26.0-0"
 name: paperless-ngx
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     condition: tika.enabled
     version: ~2.9
   - name: gotenberg
-    repository: oci://ghcr.io/adnoctem/helm
+    repository: oci://ghcr.io/adnoctem/charts
     condition: gotenberg.enabled
     version: ~0.3.0
 description: Paperless-NGX is a community-supported supercharged version of paperless - scan, index and archive all your physical documents
@@ -34,7 +34,7 @@ keywords:
   - paper
   - paperless
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -52,9 +52,9 @@ annotations:
       image: ghcr.io/paperless-ngx/paperless-ngx:2.4.0
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Paperless-NGX GitHub Repository
       url: https://github.com/paperless-ngx/paperless-ngx
     - name: Paperless-NGX Documentation

--- a/charts/paperless-ngx/README.md
+++ b/charts/paperless-ngx/README.md
@@ -30,14 +30,14 @@ on [GitHub Container Registry](https://github.com/paperless-ngx/paperless-ngx/pk
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install paperless-ngx adnoctem/paperless-ngx --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/paperless-ngx:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/paperless-ngx:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/paperless-ngx/ci/test-values.yaml
+++ b/charts/paperless-ngx/ci/test-values.yaml
@@ -9,11 +9,9 @@ paperless:
     adminPassword: "admin-pass"
 
   redis:
-    host: paperless-redis-master
     password: "paperless"
 
   postgresql:
-    host: "paperless-postgresql"
     port: 5432
     name: "paperless"
     user: "paperless"

--- a/charts/paperless-ngx/ci/test-values.yaml
+++ b/charts/paperless-ngx/ci/test-values.yaml
@@ -1,5 +1,5 @@
 paperless:
-  domain: paperless.helm.internal
+  domain: paperless.charts.internal
   secretKey:
     value: "PretendThisIsASecretKey"
 
@@ -34,9 +34,9 @@ ingress:
   tls:
     - secretName: domain-tld-tls
       hosts:
-        - paperless.helm.internal
+        - paperless.charts.internal
   extraHosts:
-    - host: paperless.helm.internal
+    - host: paperless.charts.internal
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/paperless-ngx.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -1118,7 +1118,7 @@ tika:
 ##
 
 ## Gotenberg configuration
-## ref: https://github.com/adnoctem/helm/blob/main/charts/gotenberg/values.yaml
+## ref: https://github.com/adnoctem/charts/blob/main/charts/gotenberg/values.yaml
 gotenberg:
   ## @param gotenberg.enabled Enable or disable the Gotenberg subchart
   ##

--- a/charts/popeye/Chart.yaml
+++ b/charts/popeye/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - push-gateway
   - popeye
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -35,9 +35,9 @@ annotations:
       image: docker.io/derailed/popeye:v0.21.3
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: ntfy GitHub Repository
       url: https://github.com/derailed/popeye
     - name: ntfy Documentation

--- a/charts/popeye/Chart.yaml
+++ b/charts/popeye/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 0.21.3
 kubeVersion: ">=1.26.0-0"
 name: popeye
-version: 0.2.1
+version: 0.2.2
 description: Popeye is a utility that scans live Kubernetes clusters and reports potential issues with deployed resources and configurations
 home: https://popeyecli.io/
 icon: https://github.com/derailed/popeye/blob/d09ec25f3834d2c6a171486b9726b0a91793e3f0/assets/popeye_logo.png?raw=true

--- a/charts/popeye/README.md
+++ b/charts/popeye/README.md
@@ -21,14 +21,14 @@ on [Docker Hub](https://hub.docker.com/r/derailed/popeye).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install ntfy adnoctem/popeye --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/popeye:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/popeye:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/popeye/values.yaml
+++ b/charts/popeye/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/popeye.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 1.23.13
 kubeVersion: ">=1.26.0-0"
 name: uptime-kuma
-version: 0.3.1
+version: 0.3.2
 description: Uptime-Kuma is an open-source, self-hosted fancy uptime monitoring tool
 home: https://uptime.kuma.pet/
 icon: https://raw.githubusercontent.com/louislam/uptime-kuma/953058c6a5047c82a58606e442c6e572e215e3ff/public/icon-512x512.png

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - tls
   - uptime-robot
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -35,9 +35,9 @@ annotations:
       image: docker.io/louislam/uptime-kuma:1.23.13
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Uptime-Kuma Homepage
       url: https://uptime.kuma.pet/
     - name: Uptime-Kuma Documentation

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -19,14 +19,14 @@ on [Docker Hub](https://hub.docker.com/r/louislam/uptime-kuma).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install uptime-kuma adnoctem/uptime-kuma --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/uptime-kuma:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/uptime-kuma:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/uptime-kuma/ci/test-values.yaml
+++ b/charts/uptime-kuma/ci/test-values.yaml
@@ -6,14 +6,14 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     cert-manager.io/cluster-issuer: mkcert-development-issuer
   hosts:
-    - host: uptime-kuma.helm.internal
+    - host: uptime-kuma.charts.internal
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls:
     - secretName: uptime-kuma-ingress-tls
       hosts:
-        - uptime-kuma.helm.internal
+        - uptime-kuma.charts.internal
 
 livenessProbe:
   enabled: true

--- a/charts/uptime-kuma/templates/ingress.yaml
+++ b/charts/uptime-kuma/templates/ingress.yaml
@@ -40,22 +40,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.uptimeKuma.host | quote }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ include "uptimeKuma.fullname" $ }}
-                port:
-                  number: {{ $.Values.uptimeKuma.port }}
-              {{- else }}
-              serviceName: {{ include "uptimeKuma.fullname" $ }}
-              servicePort: {{ $.Values.uptimeKuma.port }}
-              {{- end }}
-  {{- range .Values.ingress.extraHosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/uptime-kuma.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - keepass
   - vaultwarden
 sources:
-  - "https://github.com/adnoctem/helm"
+  - "https://github.com/adnoctem/charts"
 maintainers:
   - name: adnoctem
     email: info@adnoctem.co
@@ -34,9 +34,9 @@ annotations:
       image: docker.io/vaultwarden/server:1.30.5-alpine
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/adnoctem/helm
+      url: https://github.com/adnoctem/charts
     - name: Support
-      url: https://github.com/adnoctem/helm/issues
+      url: https://github.com/adnoctem/charts/issues
     - name: Vaultwarden GitHub Repository
       url: https://github.com/dani-garcia/vaultwarden
     - name: Vaultwarden Documentation

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 1.30.5
 kubeVersion: ">=1.26.0-0"
 name: vaultwarden
-version: 0.3.1
+version: 0.3.2
 description: Vaultwarden is an open-source, community-supported, Bitwarden-compatible server written in Rust
 home: https://github.com/dani-garcia/vaultwarden
 icon: https://github.com/adnoctem/artwork/blob/425046029eaed451f5ced22ddc650059dff11878/projects/vaultwarden/icon/black/vaultwarden-icon-black.png

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -17,14 +17,14 @@ on [Docker Hub](https://hub.docker.com/r/vaultwarden/server).
 ### Helm Repository Installation
 
 ```shell
-helm repo add adnoctem https://adnoctem.github.io/helm
+helm repo add adnoctem https://adnoctem.github.io/charts
 helm install vaultwarden adnoctem/vaultwarden --version X.Y.Z
 ```
 
 ### OCI Installation
 
 ```shell
-helm install oci://ghcr.io/adnoctem/helm/vaultwarden:X.Y.Z
+helm install oci://ghcr.io/adnoctem/charts/vaultwarden:X.Y.Z
 ```
 
 ## Introduction

--- a/charts/vaultwarden/ci/test-values.yaml
+++ b/charts/vaultwarden/ci/test-values.yaml
@@ -1,5 +1,5 @@
 vaultwarden:
-  domain: "vaultwarden.helm.internal"
+  domain: "vaultwarden.charts.internal"
   adminToken:
     value: "PretendThisIsAnAdminToken"
 
@@ -12,7 +12,7 @@ vaultwarden:
       username: ""
       password: ""
       auth: "Plain"
-      helloName: "vaultwarden.helm.internal"
+      helloName: "vaultwarden.charts.internal"
       acceptInvalidHostnames: true
       acceptInvalidCertificates: true
 
@@ -37,7 +37,7 @@ ingress:
   tls:
     - secretName: vaultwarden-ingress-tls
       hosts:
-        - "vaultwarden.helm.internal"
+        - "vaultwarden.charts.internal"
 
 rbac:
   create: true

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -1,5 +1,5 @@
 # Default Helm values for adnoctem/vaultwarden.
-# Reference: https://github.com/adnoctem/helm
+# Reference: https://github.com/adnoctem/charts
 
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/config/cr-config.yaml
+++ b/config/cr-config.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/helm/chart-releaser#config-file
 owner: adnoctem
-git-repo: helm
+git-repo: charts
 sign: true
 generate-release-notes: true
 skip-existing: true

--- a/config/k8s/cluster/kind-config.yaml
+++ b/config/k8s/cluster/kind-config.yaml
@@ -12,10 +12,6 @@ nodes:
           kubeletExtraArgs:
             node-labels: "ingress-ready=true"
     extraPortMappings:
-      - containerPort: 22
-        hostPort: 22
-        protocol: TCP
-        listenAddress: "0.0.0.0"
       - containerPort: 80
         hostPort: 80
         protocol: TCP

--- a/scripts/hosts.sh
+++ b/scripts/hosts.sh
@@ -23,25 +23,25 @@ HOST_CONFIGS=(
 	'/etc/hosts'
 )
 
-CONFIG_START="# HELM MANAGED START"
-CONFIG_END="# HELM MANAGED END"
+CONFIG_START="# CHARTS MANAGED START"
+CONFIG_END="# CHARTS MANAGED END"
 
 CONFIG=$(
 	cat <<EOF
 ${CONFIG_START}
-# This file is managed by Ad Noctem Collective's Helm - do not modify!
+# This file is managed by Ad Noctem Collective's Helm Charts - do not modify!
 
 # adnoctem/helm - Ad Noctem Collective Helm Charts
-127.0.0.1               linkwarden.helm.internal         # Linkwarden
-127.0.0.1               vaultwarden.helm.internal        # Vaultwarden
-127.0.0.1               uptime-kuma.helm.internal        # Uptime-Kuma
-127.0.0.1               paperless.helm.internal          # Paperless-NGX
-127.0.0.1               gotenberg.helm.internal          # Gotenberg
-127.0.0.1               linkstack.helm.internal          # Linkstack
-127.0.0.1               ntfy.helm.internal               # ntfy
-127.0.0.1               cachet.helm.internal             # Cachet
-127.0.0.1               gobackup.helm.internal           # GoBackup
-127.0.0.1               activepieces.helm.internal       # Activepieces
+127.0.0.1               linkwarden.charts.internal         # Linkwarden
+127.0.0.1               vaultwarden.charts.internal        # Vaultwarden
+127.0.0.1               uptime-kuma.charts.internal        # Uptime-Kuma
+127.0.0.1               paperless.charts.internal          # Paperless-NGX
+127.0.0.1               gotenberg.charts.internal          # Gotenberg
+127.0.0.1               linkstack.charts.internal          # Linkstack
+127.0.0.1               ntfy.charts.internal               # ntfy
+127.0.0.1               cachet.charts.internal             # Cachet
+127.0.0.1               gobackup.charts.internal           # GoBackup
+127.0.0.1               activepieces.charts.internal       # Activepieces
 
 ${CONFIG_END}
 EOF


### PR DESCRIPTION
## Summary

- Fixes stale `adnoctem/helm` references left over from the repo rename to `adnoctem/charts`: the hardcoded OCI push target in the release workflow, `chart-releaser`'s `git-repo` config, paperless-ngx's live `gotenberg` subchart dependency (this one was pulling from a path that no longer matches the repo), and every doc/annotation/link across the root README and all charts. Also renamed the `.helm.internal` local dev-hostname convention to `.charts.internal`.
- Bumps `gotenberg` from `8.7.0` to `8.36.0` (chart `0.3.1` -> `0.4.0`). Adds OpenTelemetry support, LibreOffice outbound-request filtering, Chromium/webhook IP-class filtering, opt-in environment-proxy support, and route-level telemetry controls that shipped upstream in this range. Splits the removed `pdfengines-engines` flag into its three replacement flags, and drops `chromium.incognito`, which upstream has silently ignored since 8.25. Also fixes a template bug where `readinessProbe` and `startupProbe` both rendered as a duplicate `livenessProbe` block instead of their own probe type.
- See the chart's README "Upgrading" section for the full list of value changes needed when bumping an existing gotenberg deployment.

## Test plan

- [x] `helm lint` across every chart (bare and with `ci/test-values.yaml`)
- [x] `helm template` with every new gotenberg value set, output inspected for correct flag rendering
- [x] `helm template` with all three probe types enabled, confirming the readiness/startup probe fix
- [x] JSON schema validity check on the regenerated `values.schema.json`
- [ ] CI: `Testing` workflow (ct lint + ct install on kind) passes on this PR
- [ ] After merge: `Release` workflow completes - chart pushed to `ghcr.io/adnoctem/charts/gotenberg`, signed, `gh-pages` index updated, ArtifactHub reindexes successfully