### PR TITLE
Update popeye to appVersion 0.22.1

### DIFF
--- a/charts/popeye/Chart.yaml
+++ b/charts/popeye/Chart.yaml
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 apiVersion: v2
-appVersion: 0.21.3
+appVersion: 0.22.1
 kubeVersion: ">=1.26.0-0"
 name: popeye
-version: 0.2.2
+version: 0.3.0
 description: Popeye is a utility that scans live Kubernetes clusters and reports potential issues with deployed resources and configurations
 home: https://popeyecli.io/
 icon: https://github.com/derailed/popeye/blob/d09ec25f3834d2c6a171486b9726b0a91793e3f0/assets/popeye_logo.png?raw=true
@@ -25,28 +25,34 @@ maintainers:
     email: info@mvprowess.com
 annotations:
   artifacthub.io/category: security
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/signKey: |
     fingerprint: 97DB36A8BD5E342076ED46D63E317D513290CC4B
     url: https://keys.openpgp.org/vks/v1/by-fingerprint/97DB36A8BD5E342076ED46D63E317D513290CC4B
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
-    - name: ntfy
-      image: docker.io/derailed/popeye:v0.21.3
+    - name: popeye
+      image: docker.io/derailed/popeye:v0.22.1
   artifacthub.io/links: |
     - name: Source
       url: https://github.com/adnoctem/charts
     - name: Support
       url: https://github.com/adnoctem/charts/issues
-    - name: ntfy GitHub Repository
+    - name: Popeye GitHub Repository
       url: https://github.com/derailed/popeye
-    - name: ntfy Documentation
+    - name: Popeye Documentation
       url: https://popeyecli.io/
   org.opencontainers.image.vendor: "Ad Noctem Collective"
-  org.opencontainers.image.licenses: "MIT"
+  org.opencontainers.image.licenses: "Apache-2.0"
   # ref: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: changed
       description: repository owner changed from fmjstudios to adnoctem
     - kind: fixed
       description: verify rotation of expired GPG key
+    - kind: fixed
+      description: corrected artifacthub.io/images name, link labels, and license annotations (were copy-pasted from ntfy and incorrectly listed as MIT instead of Apache-2.0)
+    - kind: changed
+      description: bump appVersion to 0.22.1 (from 0.21.3) - skips v0.21.6 and v0.22.0, both of which have upstream scanning regressions
+    - kind: added
+      description: set --force-exit-zero by default so lint findings don't leave the CronJob's Job in an Error state

--- a/charts/popeye/README.md
+++ b/charts/popeye/README.md
@@ -22,7 +22,7 @@ on [Docker Hub](https://hub.docker.com/r/derailed/popeye).
 
 ```shell
 helm repo add adnoctem https://adnoctem.github.io/charts
-helm install ntfy adnoctem/popeye --version X.Y.Z
+helm install popeye adnoctem/popeye --version X.Y.Z
 ```
 
 ### OCI Installation
@@ -43,6 +43,25 @@ all Popeye CLI arguments and [configuration files](https://popeyecli.io/#spinach
 Helm's _values_ and makes use of the official Docker Hub container image, although this is configurable via the Image
 Parameters.
 
+## Upgrading
+
+### To 0.3.0
+
+- Corrected metadata copy-pasted from the `ntfy` chart: the ArtifactHub image name, GitHub/documentation link
+  labels, and license (this chart is Apache-2.0, not MIT, as previously listed).
+- `popeye.args.force-exit-zero` now defaults to `true`. Popeye's CronJob previously left its Job in an `Error`
+  state whenever lint findings were reported, since Popeye's own exit code reflects the scan result. The Job now
+  always exits `0` regardless of findings. Set `popeye.args.force-exit-zero: false` to restore the old behavior.
+- `appVersion` bumped from `0.21.3` to `0.22.1`, skipping `0.21.6` and `0.22.0`, both of which have known upstream
+  scanning regressions.
+- Fixed a template bug where CLI arguments could render as malformed YAML (two flags concatenated onto one line)
+  depending on which flags were combined - the CLI arguments actually applied by the CronJob may change if you
+  were relying on this.
+- Fixed the S3 scan destination's auto-created Secret, which previously failed outright when no
+  `popeye.scans.s3.existingSecret` was provided (the only case where the Secret is actually needed).
+- Fixed the S3 scan destination's CLI arguments (`--s3-bucket`, `--s3-region`, `--s3-endpoint`), which previously
+  were silently dropped unless `push-gtwy` was also configured as a destination.
+
 ## Parameters
 
 ### Popeye Image parameters
@@ -51,7 +70,7 @@ Parameters.
 | ------------------- | ------------------------------------------------------------------- | ----------------- |
 | `image.registry`    | The Docker registry to pull the image from                          | `docker.io`       |
 | `image.repository`  | The registry repository to pull the image from                      | `derailed/popeye` |
-| `image.tag`         | The image tag to pull                                               | `v0.21.3`         |
+| `image.tag`         | The image tag to pull                                               | `v0.22.1`         |
 | `image.digest`      | The image digest to pull                                            | `""`              |
 | `image.pullPolicy`  | The Kubernetes image pull policy                                    | `IfNotPresent`    |
 | `image.pullSecrets` | A list of secrets to use for pulling images from private registries | `[]`              |
@@ -75,23 +94,24 @@ Parameters.
 
 ### Popeye Configuration parameters
 
-| Name                                      | Description                                                                                        | Value |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------- | ----- |
-| `popeye.config`                           | The SpinachYAML configuration for popeye                                                           | `""`  |
-| `popeye.args`                             | Define the CLI arguments and flags that the container's entrypoint will execute                    | `{}`  |
-| `popeye.scans.destinations`               | Set Scan destinations for Popeye. Valid keys are `s3` and `push-gtwy`.                             | `[]`  |
-| `popeye.scans.pushGateway.url`            | Set the URL for the Push Gateway service                                                           | `""`  |
-| `popeye.scans.pushGateway.user`           | Set the HTTP Basic Auth username for the Push Gateway service                                      | `""`  |
-| `popeye.scans.pushGateway.password`       | Set the HTTP Basic Auth password for the Push Gateway service                                      | `""`  |
-| `popeye.scans.pushGateway.existingSecret` | Provide an existing `basic-auth` Secret to use as a credential source for the Push Gateway service | `""`  |
-| `popeye.scans.s3.bucket`                  | Set the S3 bucket name                                                                             | `""`  |
-| `popeye.scans.s3.region`                  | Set the S3 region to use                                                                           | `""`  |
-| `popeye.scans.s3.endpoint`                | Set a custom S3 endpoint to use instead of the AWS one                                             | `""`  |
-| `popeye.scans.s3.accessKey`               | Set the S3 Access Key                                                                              | `""`  |
-| `popeye.scans.s3.secretKey`               | Set the S3 Secret Key                                                                              | `""`  |
-| `popeye.scans.s3.existingSecret`          | Provide an existing Secret to with `accessKey` and `secretKey` keys to use as a credential source  | `""`  |
-| `configMap.annotations`                   | Annotations for the ConfigMap resource                                                             | `{}`  |
-| `configMap.labels`                        | Extra Labels for the ConfigMap resource                                                            | `{}`  |
+| Name                                      | Description                                                                                        | Value  |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------- | ------ |
+| `popeye.config`                           | The SpinachYAML configuration for popeye                                                           | `""`   |
+| `popeye.args`                             | Define the CLI arguments and flags that the container's entrypoint will execute                    | `{}`   |
+| `popeye.args.force-exit-zero`             | Exit 0 on lint findings instead of leaving the CronJob's Job in an Error state                     | `true` |
+| `popeye.scans.destinations`               | Set Scan destinations for Popeye. Valid keys are `s3` and `push-gtwy`.                             | `[]`   |
+| `popeye.scans.pushGateway.url`            | Set the URL for the Push Gateway service                                                           | `""`   |
+| `popeye.scans.pushGateway.user`           | Set the HTTP Basic Auth username for the Push Gateway service                                      | `""`   |
+| `popeye.scans.pushGateway.password`       | Set the HTTP Basic Auth password for the Push Gateway service                                      | `""`   |
+| `popeye.scans.pushGateway.existingSecret` | Provide an existing `basic-auth` Secret to use as a credential source for the Push Gateway service | `""`   |
+| `popeye.scans.s3.bucket`                  | Set the S3 bucket name                                                                             | `""`   |
+| `popeye.scans.s3.region`                  | Set the S3 region to use                                                                           | `""`   |
+| `popeye.scans.s3.endpoint`                | Set a custom S3 endpoint to use instead of the AWS one                                             | `""`   |
+| `popeye.scans.s3.accessKey`               | Set the S3 Access Key                                                                              | `""`   |
+| `popeye.scans.s3.secretKey`               | Set the S3 Secret Key                                                                              | `""`   |
+| `popeye.scans.s3.existingSecret`          | Provide an existing Secret to with `accessKey` and `secretKey` keys to use as a credential source  | `""`   |
+| `configMap.annotations`                   | Annotations for the ConfigMap resource                                                             | `{}`   |
+| `configMap.labels`                        | Extra Labels for the ConfigMap resource                                                            | `{}`   |
 
 ### Common Secret parameters
 

--- a/charts/popeye/templates/_helpers.tpl
+++ b/charts/popeye/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Define ConfigMap names
 Define Secret names
 */}}
 {{- define "popeye.secret.scans" -}}
-{{- printf "%s-%s-config" .type (include "popeye.fullname" .) }}
+{{- printf "%s-%s-config" .type (include "popeye.fullname" .root) }}
 {{- end -}}
 
 {{/*
@@ -96,13 +96,14 @@ Define Popeye args
 {{- end -}}
 
 {{- define "popeye.arg.scans" -}}
-{{- if has "push-gtwy" .Values.popeye.scans.destinations -}}
+{{- if has "push-gtwy" .Values.popeye.scans.destinations }}
 - --push-gtwy-url {{ .Values.popeye.scans.pushGateway.url | quote }}
 {{- if .Values.popeye.scans.pushGateway.user }}
 - --push-gtwy-user {{ .Values.popeye.scans.pushGateway.user }}
 {{- end }}
 {{- if .Values.popeye.scans.pushGateway.password }}
 - --push-gtwy-password {{ .Values.popeye.scans.pushGateway.password }}
+{{- end }}
 {{- end }}
 {{- if has "s3" .Values.popeye.scans.destinations }}
 - --s3-bucket {{ .Values.popeye.scans.s3.bucket }}
@@ -113,16 +114,21 @@ Define Popeye args
 - --s3-endpoint {{ .Values.popeye.scans.s3.endpoint }}
 {{- end }}
 {{- end }}
-{{- end }}
 {{- end -}}
 
 {{- define "popeye.args" -}}
+{{- $lines := list }}
 {{- range $k, $v := (include "popeye.arg.filter" . | fromYaml) }}
-{{- if eq (toString $v) "true" -}}
-- {{ printf "--%s" (lower $k) }}
+{{- if eq (toString $v) "true" }}
+{{- $lines = append $lines (printf "- --%s" (lower $k)) }}
 {{- else }}
-- {{ printf "--%s %s" (lower $k) (lower $v) }}
+{{- $lines = append $lines (printf "- --%s %s" (lower $k) (lower $v)) }}
 {{- end }}
-{{- end -}}
-{{- include "popeye.arg.scans" . | nindent 0 }}
+{{- end }}
+{{- range (splitList "\n" (include "popeye.arg.scans" .)) }}
+{{- if . }}
+{{- $lines = append $lines . }}
+{{- end }}
+{{- end }}
+{{- join "\n" $lines }}
 {{- end -}}

--- a/charts/popeye/templates/secret.yaml
+++ b/charts/popeye/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "popeye.secret.scans" (dict "type" "s3") }}
+  name: {{ include "popeye.secret.scans" (dict "type" "s3" "root" $) }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: popeye

--- a/charts/popeye/values.schema.json
+++ b/charts/popeye/values.schema.json
@@ -1,316 +1,316 @@
 {
-    "title": "Chart Values",
-    "type": "object",
-    "properties": {
-        "image": {
-            "type": "object",
-            "properties": {
-                "registry": {
-                    "type": "string",
-                    "description": "The Docker registry to pull the image from",
-                    "default": "docker.io"
-                },
-                "repository": {
-                    "type": "string",
-                    "description": "The registry repository to pull the image from",
-                    "default": "derailed/popeye"
-                },
-                "tag": {
-                    "type": "string",
-                    "description": "The image tag to pull",
-                    "default": "v0.22.1"
-                },
-                "digest": {
-                    "type": "string",
-                    "description": "The image digest to pull",
-                    "default": ""
-                },
-                "pullPolicy": {
-                    "type": "string",
-                    "description": "The Kubernetes image pull policy",
-                    "default": "IfNotPresent"
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "description": "A list of secrets to use for pulling images from private registries",
-                    "default": [],
-                    "items": {}
-                }
-            }
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "The Docker registry to pull the image from",
+          "default": "docker.io"
         },
-        "nameOverride": {
-            "type": "string",
-            "description": "String to partially override popeye.fullname",
-            "default": ""
+        "repository": {
+          "type": "string",
+          "description": "The registry repository to pull the image from",
+          "default": "derailed/popeye"
         },
-        "fullnameOverride": {
-            "type": "string",
-            "description": "String to fully override popeye.fullname",
-            "default": ""
+        "tag": {
+          "type": "string",
+          "description": "The image tag to pull",
+          "default": "v0.22.1"
         },
-        "cronjob": {
-            "type": "object",
-            "properties": {
-                "labels": {
-                    "type": "object",
-                    "description": "Labels to attach to the CronJob manifest",
-                    "default": {}
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations to attach to the CronJob manifest",
-                    "default": {}
-                },
-                "schedule": {
-                    "type": "string",
-                    "description": "The schedule to for the CronJob. Once an hour per default.",
-                    "default": "* */1 * * *"
-                },
-                "concurrencyPolicy": {
-                    "type": "string",
-                    "description": "Concurrency is disabled for Popeye by default.",
-                    "default": "Forbid"
-                },
-                "restartPolicy": {
-                    "type": "string",
-                    "description": "Popeye containers should exit and never be auto-recreated",
-                    "default": "Never"
-                }
-            }
+        "digest": {
+          "type": "string",
+          "description": "The image digest to pull",
+          "default": ""
         },
-        "popeye": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "type": "string",
-                    "description": "The SpinachYAML configuration for popeye",
-                    "default": ""
-                },
-                "args": {
-                    "type": "object",
-                    "properties": {
-                        "force-exit-zero": {
-                            "type": "boolean",
-                            "description": "Exit 0 on lint findings instead of leaving the CronJob's Job in an Error state",
-                            "default": "true"
-                        }
-                    }
-                },
-                "scans": {
-                    "type": "object",
-                    "properties": {
-                        "destinations": {
-                            "type": "array",
-                            "description": "Set Scan destinations for Popeye. Valid keys are `s3` and `push-gtwy`.",
-                            "default": "[]",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "pushGateway": {
-                            "type": "object",
-                            "properties": {
-                                "url": {
-                                    "type": "string",
-                                    "description": "Set the URL for the Push Gateway service",
-                                    "default": "\"\""
-                                },
-                                "user": {
-                                    "type": "string",
-                                    "description": "Set the HTTP Basic Auth username for the Push Gateway service",
-                                    "default": "\"\""
-                                },
-                                "password": {
-                                    "type": "string",
-                                    "description": "Set the HTTP Basic Auth password for the Push Gateway service",
-                                    "default": "\"\""
-                                },
-                                "existingSecret": {
-                                    "type": "string",
-                                    "description": "Provide an existing `basic-auth` Secret to use as a credential source for the Push Gateway service",
-                                    "default": "\"\""
-                                }
-                            }
-                        },
-                        "s3": {
-                            "type": "object",
-                            "properties": {
-                                "bucket": {
-                                    "type": "string",
-                                    "description": "Set the S3 bucket name",
-                                    "default": "\"\""
-                                },
-                                "region": {
-                                    "type": "string",
-                                    "description": "Set the S3 region to use",
-                                    "default": "\"\""
-                                },
-                                "endpoint": {
-                                    "type": "string",
-                                    "description": "Set a custom S3 endpoint to use instead of the AWS one",
-                                    "default": "\"\""
-                                },
-                                "accessKey": {
-                                    "type": "string",
-                                    "description": "Set the S3 Access Key",
-                                    "default": "\"\""
-                                },
-                                "secretKey": {
-                                    "type": "string",
-                                    "description": "Set the S3 Secret Key",
-                                    "default": "\"\""
-                                },
-                                "existingSecret": {
-                                    "type": "string",
-                                    "description": "Provide an existing Secret to with `accessKey` and `secretKey` keys to use as a credential source",
-                                    "default": "\"\""
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        "pullPolicy": {
+          "type": "string",
+          "description": "The Kubernetes image pull policy",
+          "default": "IfNotPresent"
         },
-        "configMap": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations for the ConfigMap resource",
-                    "default": {}
-                },
-                "labels": {
-                    "type": "object",
-                    "description": "Extra Labels for the ConfigMap resource",
-                    "default": {}
-                }
-            }
-        },
-        "secret": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "description": "Common annotations for the S3 secret",
-                    "default": {}
-                },
-                "labels": {
-                    "type": "object",
-                    "description": "Common extra labels for the S3 secret",
-                    "default": {}
-                }
-            }
-        },
-        "rbac": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Whether to create RBAC resources",
-                    "default": true
-                },
-                "rules": {
-                    "type": "array",
-                    "description": "Extra rules to add to the Role",
-                    "default": [],
-                    "items": {}
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Whether a service account should be created",
-                    "default": true
-                },
-                "automount": {
-                    "type": "boolean",
-                    "description": "Whether to automount the service account token",
-                    "default": false
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations to add to the service account",
-                    "default": {}
-                },
-                "name": {
-                    "type": "string",
-                    "description": "A custom name for the service account, otherwise gobackup.fullname is used",
-                    "default": ""
-                },
-                "secrets": {
-                    "type": "array",
-                    "description": "A list of secrets mountable by this service account",
-                    "default": [],
-                    "items": {}
-                }
-            }
-        },
-        "resources": {
-            "type": "object",
-            "description": "The resource limits/requests for the Popeye pod",
-            "default": {}
-        },
-        "volumes": {
-            "type": "array",
-            "description": "Define volumes for the Popeye pod",
-            "default": [],
-            "items": {}
-        },
-        "volumeMounts": {
-            "type": "array",
-            "description": "Define volumeMounts for the Popeye pod",
-            "default": [],
-            "items": {}
-        },
-        "initContainers": {
-            "type": "array",
-            "description": "Define initContainers for the main Popeye server",
-            "default": [],
-            "items": {}
-        },
-        "nodeSelector": {
-            "type": "object",
-            "description": "Node labels for pod assignment",
-            "default": {}
-        },
-        "tolerations": {
-            "type": "array",
-            "description": "Tolerations for pod assignment",
-            "default": [],
-            "items": {}
-        },
-        "affinity": {
-            "type": "object",
-            "description": "Affinity for pod assignment",
-            "default": {}
-        },
-        "podAnnotations": {
-            "type": "object",
-            "description": "Extra annotations for the Popeye pod",
-            "default": {}
-        },
-        "podLabels": {
-            "type": "object",
-            "description": "Extra labels for the Popeye pod",
-            "default": {}
-        },
-        "priorityClassName": {
-            "type": "string",
-            "description": "The name of an existing PriorityClass",
-            "default": ""
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "description": "Security context settings for the Popeye pod",
-            "default": {}
-        },
-        "securityContext": {
-            "type": "object",
-            "description": "General security context settings for",
-            "default": {}
+        "pullSecrets": {
+          "type": "array",
+          "description": "A list of secrets to use for pulling images from private registries",
+          "default": [],
+          "items": {}
         }
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "String to partially override popeye.fullname",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "String to fully override popeye.fullname",
+      "default": ""
+    },
+    "cronjob": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "description": "Labels to attach to the CronJob manifest",
+          "default": {}
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to attach to the CronJob manifest",
+          "default": {}
+        },
+        "schedule": {
+          "type": "string",
+          "description": "The schedule to for the CronJob. Once an hour per default.",
+          "default": "* */1 * * *"
+        },
+        "concurrencyPolicy": {
+          "type": "string",
+          "description": "Concurrency is disabled for Popeye by default.",
+          "default": "Forbid"
+        },
+        "restartPolicy": {
+          "type": "string",
+          "description": "Popeye containers should exit and never be auto-recreated",
+          "default": "Never"
+        }
+      }
+    },
+    "popeye": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "string",
+          "description": "The SpinachYAML configuration for popeye",
+          "default": ""
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "force-exit-zero": {
+              "type": "boolean",
+              "description": "Exit 0 on lint findings instead of leaving the CronJob's Job in an Error state",
+              "default": "true"
+            }
+          }
+        },
+        "scans": {
+          "type": "object",
+          "properties": {
+            "destinations": {
+              "type": "array",
+              "description": "Set Scan destinations for Popeye. Valid keys are `s3` and `push-gtwy`.",
+              "default": "[]",
+              "items": {
+                "type": "string"
+              }
+            },
+            "pushGateway": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "description": "Set the URL for the Push Gateway service",
+                  "default": "\"\""
+                },
+                "user": {
+                  "type": "string",
+                  "description": "Set the HTTP Basic Auth username for the Push Gateway service",
+                  "default": "\"\""
+                },
+                "password": {
+                  "type": "string",
+                  "description": "Set the HTTP Basic Auth password for the Push Gateway service",
+                  "default": "\"\""
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "description": "Provide an existing `basic-auth` Secret to use as a credential source for the Push Gateway service",
+                  "default": "\"\""
+                }
+              }
+            },
+            "s3": {
+              "type": "object",
+              "properties": {
+                "bucket": {
+                  "type": "string",
+                  "description": "Set the S3 bucket name",
+                  "default": "\"\""
+                },
+                "region": {
+                  "type": "string",
+                  "description": "Set the S3 region to use",
+                  "default": "\"\""
+                },
+                "endpoint": {
+                  "type": "string",
+                  "description": "Set a custom S3 endpoint to use instead of the AWS one",
+                  "default": "\"\""
+                },
+                "accessKey": {
+                  "type": "string",
+                  "description": "Set the S3 Access Key",
+                  "default": "\"\""
+                },
+                "secretKey": {
+                  "type": "string",
+                  "description": "Set the S3 Secret Key",
+                  "default": "\"\""
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "description": "Provide an existing Secret to with `accessKey` and `secretKey` keys to use as a credential source",
+                  "default": "\"\""
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "configMap": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the ConfigMap resource",
+          "default": {}
+        },
+        "labels": {
+          "type": "object",
+          "description": "Extra Labels for the ConfigMap resource",
+          "default": {}
+        }
+      }
+    },
+    "secret": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "Common annotations for the S3 secret",
+          "default": {}
+        },
+        "labels": {
+          "type": "object",
+          "description": "Common extra labels for the S3 secret",
+          "default": {}
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create RBAC resources",
+          "default": true
+        },
+        "rules": {
+          "type": "array",
+          "description": "Extra rules to add to the Role",
+          "default": [],
+          "items": {}
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether a service account should be created",
+          "default": true
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Whether to automount the service account token",
+          "default": false
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account",
+          "default": {}
+        },
+        "name": {
+          "type": "string",
+          "description": "A custom name for the service account, otherwise gobackup.fullname is used",
+          "default": ""
+        },
+        "secrets": {
+          "type": "array",
+          "description": "A list of secrets mountable by this service account",
+          "default": [],
+          "items": {}
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "The resource limits/requests for the Popeye pod",
+      "default": {}
+    },
+    "volumes": {
+      "type": "array",
+      "description": "Define volumes for the Popeye pod",
+      "default": [],
+      "items": {}
+    },
+    "volumeMounts": {
+      "type": "array",
+      "description": "Define volumeMounts for the Popeye pod",
+      "default": [],
+      "items": {}
+    },
+    "initContainers": {
+      "type": "array",
+      "description": "Define initContainers for the main Popeye server",
+      "default": [],
+      "items": {}
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node labels for pod assignment",
+      "default": {}
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod assignment",
+      "default": [],
+      "items": {}
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity for pod assignment",
+      "default": {}
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Extra annotations for the Popeye pod",
+      "default": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Extra labels for the Popeye pod",
+      "default": {}
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "The name of an existing PriorityClass",
+      "default": ""
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context settings for the Popeye pod",
+      "default": {}
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "General security context settings for",
+      "default": {}
     }
+  }
 }

--- a/charts/popeye/values.schema.json
+++ b/charts/popeye/values.schema.json
@@ -1,311 +1,316 @@
 {
-  "title": "Chart Values",
-  "type": "object",
-  "properties": {
-    "image": {
-      "type": "object",
-      "properties": {
-        "registry": {
-          "type": "string",
-          "description": "The Docker registry to pull the image from",
-          "default": "docker.io"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The registry repository to pull the image from",
-          "default": "derailed/popeye"
-        },
-        "tag": {
-          "type": "string",
-          "description": "The image tag to pull",
-          "default": "v0.21.3"
-        },
-        "digest": {
-          "type": "string",
-          "description": "The image digest to pull",
-          "default": ""
-        },
-        "pullPolicy": {
-          "type": "string",
-          "description": "The Kubernetes image pull policy",
-          "default": "IfNotPresent"
-        },
-        "pullSecrets": {
-          "type": "array",
-          "description": "A list of secrets to use for pulling images from private registries",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "nameOverride": {
-      "type": "string",
-      "description": "String to partially override popeye.fullname",
-      "default": ""
-    },
-    "fullnameOverride": {
-      "type": "string",
-      "description": "String to fully override popeye.fullname",
-      "default": ""
-    },
-    "cronjob": {
-      "type": "object",
-      "properties": {
-        "labels": {
-          "type": "object",
-          "description": "Labels to attach to the CronJob manifest",
-          "default": {}
-        },
-        "annotations": {
-          "type": "object",
-          "description": "Annotations to attach to the CronJob manifest",
-          "default": {}
-        },
-        "schedule": {
-          "type": "string",
-          "description": "The schedule to for the CronJob. Once an hour per default.",
-          "default": "* */1 * * *"
-        },
-        "concurrencyPolicy": {
-          "type": "string",
-          "description": "Concurrency is disabled for Popeye by default.",
-          "default": "Forbid"
-        },
-        "restartPolicy": {
-          "type": "string",
-          "description": "Popeye containers should exit and never be auto-recreated",
-          "default": "Never"
-        }
-      }
-    },
-    "popeye": {
-      "type": "object",
-      "properties": {
-        "config": {
-          "type": "string",
-          "description": "The SpinachYAML configuration for popeye",
-          "default": ""
-        },
-        "args": {
-          "type": "object",
-          "description": "Define the CLI arguments and flags that the container's entrypoint will execute",
-          "default": {}
-        },
-        "scans": {
-          "type": "object",
-          "properties": {
-            "destinations": {
-              "type": "array",
-              "description": "Set Scan destinations for Popeye. Valid keys are `s3` and `push-gtwy`.",
-              "default": "[]",
-              "items": {
-                "type": "string"
-              }
-            },
-            "pushGateway": {
-              "type": "object",
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "description": "Set the URL for the Push Gateway service",
-                  "default": "\"\""
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "The Docker registry to pull the image from",
+                    "default": "docker.io"
                 },
-                "user": {
-                  "type": "string",
-                  "description": "Set the HTTP Basic Auth username for the Push Gateway service",
-                  "default": "\"\""
+                "repository": {
+                    "type": "string",
+                    "description": "The registry repository to pull the image from",
+                    "default": "derailed/popeye"
                 },
-                "password": {
-                  "type": "string",
-                  "description": "Set the HTTP Basic Auth password for the Push Gateway service",
-                  "default": "\"\""
+                "tag": {
+                    "type": "string",
+                    "description": "The image tag to pull",
+                    "default": "v0.22.1"
                 },
-                "existingSecret": {
-                  "type": "string",
-                  "description": "Provide an existing `basic-auth` Secret to use as a credential source for the Push Gateway service",
-                  "default": "\"\""
+                "digest": {
+                    "type": "string",
+                    "description": "The image digest to pull",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "The Kubernetes image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "A list of secrets to use for pulling images from private registries",
+                    "default": [],
+                    "items": {}
                 }
-              }
-            },
-            "s3": {
-              "type": "object",
-              "properties": {
-                "bucket": {
-                  "type": "string",
-                  "description": "Set the S3 bucket name",
-                  "default": "\"\""
-                },
-                "region": {
-                  "type": "string",
-                  "description": "Set the S3 region to use",
-                  "default": "\"\""
-                },
-                "endpoint": {
-                  "type": "string",
-                  "description": "Set a custom S3 endpoint to use instead of the AWS one",
-                  "default": "\"\""
-                },
-                "accessKey": {
-                  "type": "string",
-                  "description": "Set the S3 Access Key",
-                  "default": "\"\""
-                },
-                "secretKey": {
-                  "type": "string",
-                  "description": "Set the S3 Secret Key",
-                  "default": "\"\""
-                },
-                "existingSecret": {
-                  "type": "string",
-                  "description": "Provide an existing Secret to with `accessKey` and `secretKey` keys to use as a credential source",
-                  "default": "\"\""
-                }
-              }
             }
-          }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override popeye.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override popeye.fullname",
+            "default": ""
+        },
+        "cronjob": {
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "object",
+                    "description": "Labels to attach to the CronJob manifest",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to attach to the CronJob manifest",
+                    "default": {}
+                },
+                "schedule": {
+                    "type": "string",
+                    "description": "The schedule to for the CronJob. Once an hour per default.",
+                    "default": "* */1 * * *"
+                },
+                "concurrencyPolicy": {
+                    "type": "string",
+                    "description": "Concurrency is disabled for Popeye by default.",
+                    "default": "Forbid"
+                },
+                "restartPolicy": {
+                    "type": "string",
+                    "description": "Popeye containers should exit and never be auto-recreated",
+                    "default": "Never"
+                }
+            }
+        },
+        "popeye": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "string",
+                    "description": "The SpinachYAML configuration for popeye",
+                    "default": ""
+                },
+                "args": {
+                    "type": "object",
+                    "properties": {
+                        "force-exit-zero": {
+                            "type": "boolean",
+                            "description": "Exit 0 on lint findings instead of leaving the CronJob's Job in an Error state",
+                            "default": "true"
+                        }
+                    }
+                },
+                "scans": {
+                    "type": "object",
+                    "properties": {
+                        "destinations": {
+                            "type": "array",
+                            "description": "Set Scan destinations for Popeye. Valid keys are `s3` and `push-gtwy`.",
+                            "default": "[]",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "pushGateway": {
+                            "type": "object",
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "description": "Set the URL for the Push Gateway service",
+                                    "default": "\"\""
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "Set the HTTP Basic Auth username for the Push Gateway service",
+                                    "default": "\"\""
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "description": "Set the HTTP Basic Auth password for the Push Gateway service",
+                                    "default": "\"\""
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Provide an existing `basic-auth` Secret to use as a credential source for the Push Gateway service",
+                                    "default": "\"\""
+                                }
+                            }
+                        },
+                        "s3": {
+                            "type": "object",
+                            "properties": {
+                                "bucket": {
+                                    "type": "string",
+                                    "description": "Set the S3 bucket name",
+                                    "default": "\"\""
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "description": "Set the S3 region to use",
+                                    "default": "\"\""
+                                },
+                                "endpoint": {
+                                    "type": "string",
+                                    "description": "Set a custom S3 endpoint to use instead of the AWS one",
+                                    "default": "\"\""
+                                },
+                                "accessKey": {
+                                    "type": "string",
+                                    "description": "Set the S3 Access Key",
+                                    "default": "\"\""
+                                },
+                                "secretKey": {
+                                    "type": "string",
+                                    "description": "Set the S3 Secret Key",
+                                    "default": "\"\""
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Provide an existing Secret to with `accessKey` and `secretKey` keys to use as a credential source",
+                                    "default": "\"\""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "configMap": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the ConfigMap resource",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Extra Labels for the ConfigMap resource",
+                    "default": {}
+                }
+            }
+        },
+        "secret": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "description": "Common annotations for the S3 secret",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Common extra labels for the S3 secret",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create RBAC resources",
+                    "default": true
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Extra rules to add to the Role",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether a service account should be created",
+                    "default": true
+                },
+                "automount": {
+                    "type": "boolean",
+                    "description": "Whether to automount the service account token",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the service account",
+                    "default": {}
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A custom name for the service account, otherwise gobackup.fullname is used",
+                    "default": ""
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "A list of secrets mountable by this service account",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "description": "The resource limits/requests for the Popeye pod",
+            "default": {}
+        },
+        "volumes": {
+            "type": "array",
+            "description": "Define volumes for the Popeye pod",
+            "default": [],
+            "items": {}
+        },
+        "volumeMounts": {
+            "type": "array",
+            "description": "Define volumeMounts for the Popeye pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Define initContainers for the main Popeye server",
+            "default": [],
+            "items": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Extra annotations for the Popeye pod",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for the Popeye pod",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "The name of an existing PriorityClass",
+            "default": ""
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "description": "Security context settings for the Popeye pod",
+            "default": {}
+        },
+        "securityContext": {
+            "type": "object",
+            "description": "General security context settings for",
+            "default": {}
         }
-      }
-    },
-    "configMap": {
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "type": "object",
-          "description": "Annotations for the ConfigMap resource",
-          "default": {}
-        },
-        "labels": {
-          "type": "object",
-          "description": "Extra Labels for the ConfigMap resource",
-          "default": {}
-        }
-      }
-    },
-    "secret": {
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "type": "object",
-          "description": "Common annotations for the S3 secret",
-          "default": {}
-        },
-        "labels": {
-          "type": "object",
-          "description": "Common extra labels for the S3 secret",
-          "default": {}
-        }
-      }
-    },
-    "rbac": {
-      "type": "object",
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Whether to create RBAC resources",
-          "default": true
-        },
-        "rules": {
-          "type": "array",
-          "description": "Extra rules to add to the Role",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Whether a service account should be created",
-          "default": true
-        },
-        "automount": {
-          "type": "boolean",
-          "description": "Whether to automount the service account token",
-          "default": false
-        },
-        "annotations": {
-          "type": "object",
-          "description": "Annotations to add to the service account",
-          "default": {}
-        },
-        "name": {
-          "type": "string",
-          "description": "A custom name for the service account, otherwise gobackup.fullname is used",
-          "default": ""
-        },
-        "secrets": {
-          "type": "array",
-          "description": "A list of secrets mountable by this service account",
-          "default": [],
-          "items": {}
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "description": "The resource limits/requests for the Popeye pod",
-      "default": {}
-    },
-    "volumes": {
-      "type": "array",
-      "description": "Define volumes for the Popeye pod",
-      "default": [],
-      "items": {}
-    },
-    "volumeMounts": {
-      "type": "array",
-      "description": "Define volumeMounts for the Popeye pod",
-      "default": [],
-      "items": {}
-    },
-    "initContainers": {
-      "type": "array",
-      "description": "Define initContainers for the main Popeye server",
-      "default": [],
-      "items": {}
-    },
-    "nodeSelector": {
-      "type": "object",
-      "description": "Node labels for pod assignment",
-      "default": {}
-    },
-    "tolerations": {
-      "type": "array",
-      "description": "Tolerations for pod assignment",
-      "default": [],
-      "items": {}
-    },
-    "affinity": {
-      "type": "object",
-      "description": "Affinity for pod assignment",
-      "default": {}
-    },
-    "podAnnotations": {
-      "type": "object",
-      "description": "Extra annotations for the Popeye pod",
-      "default": {}
-    },
-    "podLabels": {
-      "type": "object",
-      "description": "Extra labels for the Popeye pod",
-      "default": {}
-    },
-    "priorityClassName": {
-      "type": "string",
-      "description": "The name of an existing PriorityClass",
-      "default": ""
-    },
-    "podSecurityContext": {
-      "type": "object",
-      "description": "Security context settings for the Popeye pod",
-      "default": {}
-    },
-    "securityContext": {
-      "type": "object",
-      "description": "General security context settings for",
-      "default": {}
     }
-  }
 }

--- a/charts/popeye/values.yaml
+++ b/charts/popeye/values.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: derailed/popeye
-  tag: v0.21.3
+  tag: v0.22.1
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -116,9 +116,27 @@ popeye:
   #          cpu:    80
   #          memory: 75
   #
-  #    # [New!] overrides code severity
+  #    # Exclude resources from being scanned entirely
+  #    excludes:
+  #      # Global excludes apply across all linters
+  #      global:
+  #        fqns: [rx:^kube-] # Regex or literal fully-qualified names to exclude
+  #        labels:
+  #          app: [bozo, bono] # Exclude resources matching these label values
+  #        annotations:
+  #          fred: [blee, duh] # Exclude resources matching these annotation values
+  #        codes: ["300", "206", "rx:^41"] # Exclude specific lint codes globally
+  #      # Per-linter excludes override/extend the global ones for a specific linter
+  #      linters:
+  #        namespaces:
+  #          codes: ["100", "rx:^22"]
+  #          instances:
+  #            - fqns: [kube-public, kube-system]
+  #            - fqns: [blee-ns]
+  #              codes: [106]
+  #
+  #    # Code specifies a custom severity level ie critical=3, warn=2, info=1
   #    overrides:
-  #      # Code specifies a custom severity level ie critical=3, warn=2, info=1
   #      - code: "rx:^20"
   #        severity: 1
   #
@@ -129,12 +147,15 @@ popeye:
   #      - docker.io
   #      - ghcr.io
 
-  ## @param popeye.args Define the CLI arguments and flags that the container's entrypoint will execute
+  ## @param popeye.args [object] Define the CLI arguments and flags that the container's entrypoint will execute
   ## NOTE: Boolean flags such as `save` are to be set to `true` to be appended. Arguments for the Push Gateway or S3
   ##        integration are configured later in the `scans` section and as such are not to be configured here as they
   ##        will not be used
+  ## @param popeye.args.force-exit-zero [default: true] Exit 0 on lint findings instead of leaving the CronJob's Job in an Error state
+  ## Set to false if you want the Job to reflect lint failures via its exit code
   ##
-  args: {}
+  args:
+    force-exit-zero: true
   # file: /etc/popeye/spinach.yaml
   # all-namespaces: true
 


### PR DESCRIPTION
## Summary

- Corrects metadata copy-pasted from the ntfy chart: ArtifactHub image name, GitHub/documentation link labels, and license (Apache-2.0, not MIT).
- Makes `force-exit-zero` the default so lint findings no longer leave the CronJob's Job in an Error state.
- Bumps `appVersion` from 0.21.3 to 0.22.1, skipping 0.21.6 and 0.22.0, both of which have known upstream scanning regressions.
- Fixes three latent template bugs found while implementing the above:
  - CLI arguments could render as malformed YAML (two flags concatenated onto one line) depending on which flags were combined.
  - The S3 scan destination's auto-created Secret failed outright whenever no `existingSecret` was given - the only case it's actually needed.
  - S3's CLI flags (`--s3-bucket`, `--s3-region`, `--s3-endpoint`) were silently dropped unless `push-gtwy` was also configured as a destination.

## Test plan

- [x] `helm lint` (bare and with `ci/test-values.yaml`)
- [x] `helm template` across all three scan-destination combinations (push-gtwy only, s3 only, both)
- [x] Full `ct lint` sweep
- [x] CI: `Testing` workflow passes on this PR
- [x] After merge: `Release` workflow completes and `popeye-0.3.0` is published